### PR TITLE
Some improvements...

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
             </table>
         </section>
 
-        <section id="selectors" class="informative">
+        <section id="selectors">
             <h3>Selectors</h3>
 
             <p>Selection of part of a <a>Web Resource</a> requires two distinct entities:</p>
@@ -248,7 +248,21 @@
             <p>
 				A <dfn>Selector</dfn> object is used to describe how to determine the <a>Segment</a> from within the <a>Source</a> resource.
 				The nature of the Selector is dependent on the type of resource, as the methods to describe Segments from various media-types differ. These two entities are encapsulated in a <a>Specific Resource</a>.
-            </p>
+			</p>
+
+			<p>
+				A Selector object MAY also have a <code>source</code> <a>Relationship</a>, relating the selection to a particular resource. In general, this relationship is not necessary, because a Selector inherits the source of its encapsulating <a>SpecificResource</a>. However, there are cases when this relationship is necessary. For example:
+			</p>
+
+			<ul>
+				<li>The inherited source is used to identify the <a href="https://www.w3.org/TR/publishing-linking/#dfn-address" class="externalDFN">address</a> of a Web Publication&nbsp;[[wpub]], and the <code>source</code> relationship is used to identify a specific <a class="externalDFN" href="https://w3c.github.io/wpub/#wp-resources">Web Publication Resource</a>.</li>
+				<li>When the Selector is a <a href="#RangeSelector_def"></a>, the <code>source</code> value can be used to refer to different resources within the same <a>SpecificResource</a>.</li>
+			</ul>
+
+			<p class="note">
+				The ability of using a <code>source</code> within a Selector is the <em>only</em> extension to the Selectors as defined by the Web Annotation Model&nbsp;[[annotation-model]]
+			</p>
+
 
             <p>
 				<b>Example Use Case:</b> Qitara wants to associate a selection of text in a web page with a slice of a dataset.
@@ -268,8 +282,13 @@
 						User Agents MUST pick one of the described <a data-lt="segment">segments</a>, if they are different.
                     </td>
                 </tr>
-            </table>
-
+                <tr>
+						<td>source</td>
+						<td>Relationship</td>
+						<td>The relationship between a Selector and the resource that it is a more specific representation of, i.e., the <a>Source</a>.
+						<br/>There MUST be at most 1 <code>source</code> relationship associated with a Specific Resource.  The source resource SHOULD be a URL.</td>
+				</tr>
+			</table>
             <h4>Example</h4>
 
             <pre class="example highlight" title="Selectors">
@@ -373,7 +392,7 @@
 				</p>
 
                 <p>
-					<b>Example Use Case:</b> Sally selects a paragraph in a web page that she wishes bookmark.  
+					<b>Example Use Case:</b> Sally selects a paragraph in a one of the chapters of a Web Publications that she wishes bookmark.  
 					Her client calculates a CSS path that cleanly identifies that element and stores CSS Selector in its local bookmark store .
 				</p>
 
@@ -408,9 +427,10 @@
 
                 <pre class="example highlight" title="CSS Selector" id="CssSelector_ex">
 {
-	"source": "http://example.org/page1.html",
+	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
 	"selector": {
 		"type": "CssSelector",
+		"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html"
 		"value": "#elemid > .elemclass + p"
 	}
 }
@@ -1112,10 +1132,11 @@
 						<li>otherwise the key, and the corresponding value, follows the simple <code>key=value</code> syntax, e.g., <code>type=FragmentSelector</code>.</li>
 					</ul>
 				</li>
-				<li>For types and properties other than those specified in the Web Annotation model, the full URL MUST be used.</li>
 			</ul>
 
 			<p>(see the examples below.)</p>
+
+			<p class="ednote">The reference to the Web Publication Resources should be changed to use the short name of the WP specification, as opposed to the editor's draft like now.</p>
 
 			<p>The values SHOULD be percent encoded&nbsp;[[rfc3986]]; the encoding is a MUST for characters that may make the fragment ambiguous, namely:</p>
 
@@ -1178,10 +1199,11 @@
 
 				<p class="ex_title"><a href="#CssSelector_ex">Example</a> for a <a href="#CssSelector_def"></a></p>
 				<pre class="example nohighlight" title="CSS Selector as Fragment" id="CssSelector_frag">
-				http://example.org/page1.html#selector(
+				https://dauwhe.github.io/html-first/MobyDick.wpub(
 					type=CssSelector,
-					value=%23elemid%20>%20.elemclass%20+%20p
-				)
+					source=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
+					value=%23elemid%20>%20.elemclass%20+%20p,
+				)				 
 				</pre>
 
 				<p class="ex_title"><a href="#XPathSelector_ex">Example</a> for a <a href="#XPathSelector_def"></a></p>

--- a/index.html
+++ b/index.html
@@ -754,12 +754,15 @@
 					A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors.
 					In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection.
 					The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.
+					Because any Selector may have its own <code>source</code>, Range Selectors can also be used to bridge over several resources. In those cases, however, the exact semantics for such a selection must be defined by the time of collection the Selection is used for.
 				</p>
 
+				<p class="issue" data-number=1></p>
+				<p class="issue" data-number=2></p>				
+				
 				<p>
-					<b>Example Use Case:</b> Yadira wants to comment on two adjacent cells in a table that is part of a web page.
-					She selects the two cells and her client constructs XPaths to the the first cell, and the cell that immediately follows the second.
-					Her client then creates a Range Selector with the first XPath Selector as the start, and the second XPath selector as the end.
+					<b>Example Use Case:</b> Yadira wants to comment on text in a Web Publication that spreads over two adjacent consituent HTML files (representing the chapters of the book published in a Web Publication).
+					She selects the start and the end of the selection in the respective HTML files, and uses the address of the Web Publication&nbsp;[[wpub]] as a source for the overall Selector.
 				</p>
 
 				<h4>Model</h4>
@@ -792,16 +795,21 @@
 
 				<pre class="example highlight" title="Range Selector" id="RangeSelector_ex">
 				{
-					"source": "http://example.org/page1.html",
+					"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
 					"selector": {
 						"type": "RangeSelector",
 						"startSelector": {
-							"type": "XPathSelector",
-							"value": "//table[1]/tr[1]/td[2]"
+							"type": "TextQuoteSelector",
+							"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+							"exact": "Call me Ishmael.",
+							"suffix": "Some years ago"
 						},
 						"endSelector": {
-							"type": "XPathSelector",
-							"value": "//table[1]/tr[1]/td[4]"
+							"type": "TextQuoteSelector",
+							"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html",
+							"exact": "A hundred black faces turned round",
+							"suffix": " in their rows",
+							"prefix": "sitting in Tophet. "
 						}
 					}
 				}
@@ -1147,7 +1155,7 @@
 
 				<p>
 					This section contains a mapping of all examples used in the definion of <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> onto full URL-s with fragment identifiers.
-					Note that the examples below have been, in some cases, broken into several lines for a greater readability; in real usage such new lines are not allowed in a URL.
+					Note that the examples below have been broken into several lines for a greater readability; in real usage such new lines are not allowed in a URL.
 				</p>
 
 				<!-- <p class="note">
@@ -1156,53 +1164,71 @@
 
 				<p class="ex_title"><a href="#FragmentSelector_ex">Example</a> for a <a href="#FragmentSelector_def"></a></p>
 				<pre class="example nohighlight" title="Fragment Selector as Fragment" id="FragmentSelector_frag">
-				http://example.org/video1
-					#selector(type=FragmentSelector,conformsTo=http://www.w3.org/TR/media-frags,
-							value=t%3D30%2C60)
+				http://example.org/video1#selector(
+					type=FragmentSelector,
+					conformsTo=http://www.w3.org/TR/media-frags,
+					value=t%3D30%2C60
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#CssSelector_ex">Example</a> for a <a href="#CssSelector_def"></a></p>
 				<pre class="example nohighlight" title="CSS Selector as Fragment" id="CssSelector_frag">
-				http://example.org/page1.html
-					#selector(type=CssSelector,value=%23elemid%20>%20.elemclass%20+%20p)
+				http://example.org/page1.html#selector(
+					type=CssSelector,
+					value=%23elemid%20>%20.elemclass%20+%20p
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#XPathSelector_ex">Example</a> for a <a href="#XPathSelector_def"></a></p>
 				<pre class="example nohighlight" title="XPath Selector as Fragment" id="XPathSelector_frag">
-				http://example.org/page1.html
-					#selector(type=XPathSelector,value=/html/body/p[2]/table/tr[2]/td[3]/span)
+				http://example.org/page1.html#selector(
+					type=XPathSelector,
+					value=/html/body/p[2]/table/tr[2]/td[3]/span
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#TextQuoteSelector_ex">Example</a> for a <a href="#TextQuoteSelector_def"></a></p>
 				<pre class="example nohighlight" title="Text Quote Selector as Fragment" id="TextQuoteSelector_frag">
-				http://example.org/page1
-					#selector(type=TextQuoteSelector,exact=annotation,prefix=this%20is%20an%20,
-							suffix=%20that%20has%20some)
+				http://example.org/page1#selector(
+					type=TextQuoteSelector,
+					exact=annotation,
+					prefix=this%20is%20an%20,
+					suffix=%20that%20has%20some
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#TextPositionSelector_ex">Example</a> for a <a href="#TextPositionSelector_def"></a></p>
 				<pre class="example nohighlight" title="Text Position Selector as Fragment" id="TextPositionSelector_frag">
-				http://example.org/ebook1
-					#selector(type=TextPositionSelector,start=412,end=795)
+				http://example.org/ebook1#selector(
+					type=TextPositionSelector,
+					start=412,
+					end=795
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#DataPositionSelector_ex">Example</a> for a <a href="#DataPositionSelector_def"></a></p>
 				<pre class="example nohighlight" title="Data Position Selector as Fragment" id="DataPositionSelector_frag">
-				http://example.org/diskimg1
-					#selector(type=DataPositionSelector,start=4096,end=4104)
+				http://example.org/diskimg1#selector(
+					type=DataPositionSelector,
+					start=4096,
+					end=4104
+				)
 				</pre>
 
 				<p class="ex_title">First <a href="#SvgSelector_ex_1">example</a> for a <a href="#SvgSelector_def"></a></p>
 				<pre class="example nohighlight" title="SVG Selector as Fragment, referring to an external SVG" id="SvgSelector_frag_1">
-				http://example.org/map1
-					#selector(type=SvgSelector,id=http://example.org/svg1)
+				http://example.org/map1#selector(
+					type=SvgSelector,
+					id=http://example.org/svg1
+				)
 				</pre>
 
 				<p class="ex_title">Second <a href="#SvgSelector_ex_2">example</a> for a <a href="#SvgSelector_def"></a></p>
 				<pre class="example nohighlight" title="SVG Selector as Fragment, using embedded SVG" id="SvgSelector_frag_2">
-					http://example.org/map1
-						#selector(type=SvgSelector,
-								value=&lt;svg:svg&gt;%20...%20&lt;/svg:svg&gt;)
+				http://example.org/map1#selector(
+					type=SvgSelector,
+					value=&lt;svg:svg&gt;%20…%20&lt;/svg:svg&gt;
+				)
 				</pre>
 
 				<p>
@@ -1212,38 +1238,63 @@
 
 				<p class="ex_title"><a href="#RangeSelector_ex">Example</a> for a <a href="#RangeSelector_def"></a></p>
 				<pre class="example nohighlight" title="Range Selector as Fragment" id="RangeSelector_frag">
-				http://example.org/page1.html
-					#selector(type=RangeSelector,
-							startSelector=selector(type=XPathSelector,value=//table[1]/tr[1]/td[2]),
-							endSelector=selector(type=XPathSelector,value=//table[1]/tr[1]/td[4]))
+				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
+					type=RangeSelector,
+					startSelector=selector(
+						source=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
+						type=TextQuoteSelector,
+						exact=Call%20me%20Ishmael.,
+						suffix=Some%20years%20ago
+					),
+					startSelector=selector(
+						source=https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html,
+						type=TextQuoteSelector,
+						exact=A%20hundred%20black%20faces%20turned%20round,
+						suffix=Some%20years%20ago
+						suffix=%20in%20their%20rows,
+						prefix=sitting%20in%20Tophet.%20
+					)
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#SelectorRefinement_ex">Example</a> for a <a href="#SelectorRefinement_def"></a></p>
 				<pre class="example nohighlight" title="Selector Refinement as Fragment" id="SelectorRefinement_frag">
-				http://example.org/page1
-					#selector(type=FragmentSelector,value=para5,
-							refinedBy=selector(type=TextQuoteSelector,exact=Selected%20Text,
-										prefix=text%20before%20the%20,suffix=%20and%20text%20after%20it))
+				http://example.org/page1#selector(
+					type=FragmentSelector,value=para5,
+					refinedBy=selector(
+					type=TextQuoteSelector,exact=Selected%20Text,
+					prefix=text%20before%20the%20,
+					suffix=%20and%20text%20after%20it
+					)
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#TimeState_ex">Example</a> for a <a href="#TimeState_def"></a></p>
 				<pre class="example nohighlight" title="Time State as Fragment" id="TimeState_frag">
-				http://example.org/page1
-					#state(type=TimeState,cached=http://archive.example.org/copy1,
-						sourceDate=2015-07-20T13:30:00Z)
+				http://example.org/page1#state(
+					type=TimeState,
+					cached=http://archive.example.org/copy1,
+					sourceDate=2015-07-20T13:30:00Z
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#HttpRequestState_ex">Example</a> for a <a href="#HttpRequestState_def"></a></p>
 				<pre class="example nohighlight" title="HTTP Request State as Fragment" id="HttpRequestState_frag">
-				http://example.org/resource1
-					#state(type=HttpRequestState,value=Accept:%20application/pdf)
+				http://example.org/resource1#state(
+					type=HttpRequestState,
+					value=Accept:%20application/pdf
+				)
 				</pre>
 
 				<p class="ex_title"><a href="#StateRefinement_def">Example</a> for a <a href="#StateRefinement_def"></a></p>
 				<pre class="example nohighlight" title="Refinement of States as Fragment" id="StateRefinement_frag">
-				http://example.org/ebook1
-					#state(type=TimeState,sourceDate=2016-02-01T12:05:23Z,
-						refinedBy=state(type=HttpRequestState,value=Accept:%20application/epub+zip))
+				http://example.org/ebook1#state(
+					type=TimeState,sourceDate=2016-02-01T12:05:23Z,
+					refinedBy=state(
+					type=HttpRequestState,
+					value=Accept:%20application/epub+zip
+					)
+				)
 				</pre>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -107,10 +107,7 @@
 				Some features have been added (e.g., <code>scope</code>), whereas some sections and references have been removed (e.g., reference to RDF or JSON-LD contexts).
 			</p>
 								
-			<p class="issue">
-				The document consists of two parts: a description of, essentially, the Selector Model as defined by the Web Annotation Data Model, and a reformulation of that data model in the form of Fragment ID-s. 
-				It is not clear, at this moment, whether the standardization of fragment identifiers is necessary, or whether the JSON based structure fulfills the needs of the requirements. If the latter, then this document does not add any normative feature, and may end up as a Working Group Note.
-			</p>
+			<p class="issue" data-number=6></p>
 
 		</section>
 

--- a/index.html
+++ b/index.html
@@ -429,7 +429,7 @@
 	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
 	"selector": {
 		"type": "CssSelector",
-		"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html"
+		"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
 		"value": "#elemid > .elemclass + p"
 	}
 }

--- a/index.html
+++ b/index.html
@@ -273,10 +273,10 @@
             <h4>Example</h4>
 
             <pre class="example highlight" title="Selectors">
-            {
-                "source": "http://example.org/page1",
-                "selector": "http://example.org/paraselector1"
-            }
+{
+	"source": "http://example.org/page1",
+	"selector": "http://example.org/paraselector1"
+}
             </pre>
 
             <section id="FragmentSelector_def">
@@ -352,14 +352,14 @@
                 <h4>Example</h4>
 
                 <pre class="example highlight" title="Fragment Selector" id="FragmentSelector_ex">
-                {
-                    "source": "http://example.org/video1",
-                    "selector": {
-                      "type": "FragmentSelector",
-                      "conformsTo": "http://www.w3.org/TR/media-frags/",
-                      "value": "t=30,60"
-                    }
-                }
+{
+	"source": "http://example.org/video1",
+	"selector": {
+		"type": "FragmentSelector",
+		"conformsTo": "http://www.w3.org/TR/media-frags/",
+		"value": "t=30,60"
+	}
+}
                 </pre>
             </section>
 
@@ -373,7 +373,8 @@
 				</p>
 
                 <p>
-					<b>Example Use Case:</b> Sally selects a paragraph in a web page that she wishes remove.  Her client calculates a CSS path that cleanly identifies that element to be deleted.
+					<b>Example Use Case:</b> Sally selects a paragraph in a web page that she wishes bookmark.  
+					Her client calculates a CSS path that cleanly identifies that element and stores CSS Selector in its local bookmark store .
 				</p>
 
                 <h4>Model</h4>
@@ -406,13 +407,13 @@
                 <h4>Example</h4>
 
                 <pre class="example highlight" title="CSS Selector" id="CssSelector_ex">
-                {
-                    "source": "http://example.org/page1.html",
-                    "selector": {
-                      "type": "CssSelector",
-                      "value": "#elemid > .elemclass + p"
-                    }
-                }
+{
+	"source": "http://example.org/page1.html",
+	"selector": {
+		"type": "CssSelector",
+		"value": "#elemid > .elemclass + p"
+	}
+}
                 </pre>
             </section>
 
@@ -464,13 +465,13 @@
                 <h4>Example</h4>
 
                 <pre class="example highlight" title="XPath Selector" id="XPathSelector_ex">
-                {
-                    "source": "http://example.org/page1.html",
-                    "selector": {
-                      "type": "XPathSelector",
-                      "value": "/html/body/p[2]/table/tr[2]/td[3]/span"
-                    }
-                }
+{
+	"source": "http://example.org/page1.html",
+	"selector": {
+		"type": "XPathSelector",
+		"value": "/html/body/p[2]/table/tr[2]/td[3]/span"
+	}
+}
                 </pre>
             </section>
 
@@ -545,15 +546,15 @@
                 <h4>Example</h4>
 
                 <pre class="example highlight" title="Text Quote Selector" id="TextQuoteSelector_ex">
-                {
-                    "source": "http://example.org/page1",
-                    "selector": {
-                      "type": "TextQuoteSelector",
-                      "exact": "anotation",
-                      "prefix": "this is an ",
-                      "suffix": " that has some"
-                    }
-                }
+{
+	"source": "http://example.org/page1",
+	"selector": {
+		"type": "TextQuoteSelector",
+		"exact": "anotation",
+		"prefix": "this is an ",
+		"suffix": " that has some"
+	}
+}
                 </pre>
             </section>
 
@@ -615,14 +616,14 @@
             	<h4>Example</h4>
 
 				<pre class="example highlight" title="Text Position Selector" id="TextPositionSelector_ex">
-				{
-					"source": "http://example.org/ebook1",
-					"selector": {
-					"type": "TextPositionSelector",
-					"start": 412,
-					"end": 795
-					}
-				}
+{
+	"source": "http://example.org/ebook1",
+	"selector": {
+		"type": "TextPositionSelector",
+		"start": 412,
+		"end": 795
+	}
+}
 	            </pre>
         	</section>
 
@@ -631,7 +632,9 @@
 
             	<p>Similar to the <a href="#TextPositionSelector_def">Text Position Selector</a>, the Data Position Selector uses the same properties but works at the byte in bitstream level rather than the character in text level.</p>
 
-            	<p><b>Example Use Case:</b> Wendy produces visualizations of regions of online disk images for forensic purposes.  Her client generates the start and end positions from the binary stream, rather than the more human readable display she is using.</p>
+				<p><b>Example Use Case:</b> Wendy produces visualizations of regions of online disk images for as part of her publication.
+					She calculates the start and end positions from the binary stream and stores that as a reference using the DataPositionSelector.
+				</p>
 
 
             	<h4>Model</h4>
@@ -663,14 +666,14 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="Data Position Selector" id="DataPositionSelector_ex">
-				{
-					"source": "http://example.org/diskimg1",
-					"selector": {
-					"type": "DataPositionSelector",
-					"start": 4096,
-					"end": 4104
-					}
-				}
+{
+	"source": "http://example.org/diskimg1",
+	"selector": {
+		"type": "DataPositionSelector",
+		"start": 4096,
+		"end": 4104
+	}
+}
 				</pre>
         	</section>
 
@@ -762,7 +765,7 @@
 				
 				<p>
 					<b>Example Use Case:</b> Yadira wants to comment on text in a Web Publication that spreads over two adjacent consituent HTML files (representing the chapters of the book published in a Web Publication).
-					She selects the start and the end of the selection in the respective HTML files, and uses the address of the Web Publication&nbsp;[[wpub]] as a source for the overall Selector.
+					She selects the start and the end of the selection in the respective HTML files; her User Agent calculates the Range Selector using the address of the Web Publication&nbsp;[[wpub]] as a source for the overall Selector.
 				</p>
 
 				<h4>Model</h4>
@@ -794,25 +797,25 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="Range Selector" id="RangeSelector_ex">
-				{
-					"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-					"selector": {
-						"type": "RangeSelector",
-						"startSelector": {
-							"type": "TextQuoteSelector",
-							"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-							"exact": "Call me Ishmael.",
-							"suffix": "Some years ago"
-						},
-						"endSelector": {
-							"type": "TextQuoteSelector",
-							"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html",
-							"exact": "A hundred black faces turned round",
-							"suffix": " in their rows",
-							"prefix": "sitting in Tophet. "
-						}
-					}
-				}
+{
+	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+	"selector": {
+		"type": "RangeSelector",
+		"startSelector": {
+			"type": "TextQuoteSelector",
+			"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+			"exact": "Call me Ishmael.",
+			"suffix": "Some years ago"
+		},
+		"endSelector": {
+			"type": "TextQuoteSelector",
+			"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html",
+			"exact": "A hundred black faces turned round",
+			"suffix": " in their rows",
+			"prefix": "sitting in Tophet. "
+		}
+	}
+}
 				</pre>
 			</section>
 
@@ -844,19 +847,19 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="Selector Refinement" id="SelectorRefinement_ex">
-				{
-					"source": "http://example.org/page1",
-					"selector": {
-						"type": "FragmentSelector",
-						"value": "para5",
-						"refinedBy": {
-							"type": "TextQuoteSelector",
-							"exact": "Selected Text",
-							"prefix": "text before the ",
-							"suffix": " and text after it"
-						}
-					}
-				}
+{
+	"source": "http://example.org/page1",
+	"selector": {
+		"type": "FragmentSelector",
+		"value": "para5",
+		"refinedBy": {
+			"type": "TextQuoteSelector",
+			"exact": "Selected Text",
+			"prefix": "text before the ",
+			"suffix": " and text after it"
+		}
+	}
+}
 				</pre>
 			</section>
 		</section> <!-- /Selectors -->
@@ -904,12 +907,12 @@
 			<h4>Example</h4>
 
 			<pre class="example highlight" title="State">
-			{
-				"source": "http://example.org/page1",
-				"state": {
-					"id": "http://example.org/state1"
-				}
-			}
+{
+	"source": "http://example.org/page1",
+	"state": {
+		"id": "http://example.org/state1"
+	}
+}
 			</pre>
 
 			<section id="TimeState_def">
@@ -965,14 +968,14 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="Time State" id="TimeState_ex">
-				{
-					"source": "http://example.org/page1",
-					"state": {
-						"type": "TimeState",
-						"cached": "http://archive.example.org/copy1",
-						"sourceDate": "2015-07-20T13:30:00Z"
-					}
-				}
+{
+	"source": "http://example.org/page1",
+	"state": {
+		"type": "TimeState",
+		"cached": "http://archive.example.org/copy1",
+		"sourceDate": "2015-07-20T13:30:00Z"
+	}
+}
 				</pre>
 			</section>
 
@@ -1019,13 +1022,13 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="HTTP Request State" id="HttpRequestState_ex">
-				{
-					"source": "http://example.org/resource1",
-					"state": {
-					"type": "HttpRequestState",
-						"value": "Accept: application/pdf"
-					}
-				}
+{
+	"source": "http://example.org/resource1",
+	"state": {
+		"type": "HttpRequestState",
+		"value": "Accept: application/pdf"
+	}
+}
 				</pre>
 			</section>
 
@@ -1145,9 +1148,11 @@
 			</table>
 
 			<div class="note">
-				<p>A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section should be registered for each media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
+				<p>
+					A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section should be registered for each media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
 					Until such a registration is done, these fragment identifiers have the potential to conflict with other fragments possibly specified by the media type registrations.
-					Consequently, this pattern should only be used when the implementation cannot produce or manage the full representation described above. </p>
+					Consequently, this pattern should only be used when the implementation cannot produce or manage the full representation described above. 
+				</p>
 			</div>
 
 			<section>

--- a/index.html
+++ b/index.html
@@ -960,7 +960,7 @@
 					<tr>
 						<td>TimeState</td>
 						<td>Class</td>
-						<td>A description of how to retrieve a representation of the Source resource that is temporally appropriate for the Annotation. <br/>The State MUST have this class associated with it.</td>
+						<td>A description of how to retrieve a representation of the <a>Source</a> resource that is temporally appropriate for the Annotation. <br/>The State MUST have this class associated with it.</td>
 					</tr>
 					<tr>
 						<td>sourceDate</td>
@@ -970,17 +970,17 @@
 					<tr>
 						<td>sourceDateStart</td>
 						<td>Property</td>
-						<td>The timestamp that begins the interval over which the <p>Source</p> resource should be interpreted. <br/>There MAY be exactly 1 <code>sourceDateStart</code> property per TimeState. The timestamp MUST be expressed in the <code>xsd:dateTime</code> format, and MUST use the UTC timezone expressed as "Z". If <code>sourceDateStart</code> is provided then <code>sourceDateEnd</code> MUST also be provided.</td>
+						<td>The timestamp that begins the interval over which the <a>Source</a> resource should be interpreted. <br/>There MAY be exactly 1 <code>sourceDateStart</code> property per TimeState. The timestamp MUST be expressed in the <code>xsd:dateTime</code> format, and MUST use the UTC timezone expressed as "Z". If <code>sourceDateStart</code> is provided then <code>sourceDateEnd</code> MUST also be provided.</td>
 					</tr>
 					<tr>
 						<td>sourceDateEnd</td>
 						<td>Property</td>
-						<td>The timestamp that ends the interval over which the <p>Source</p> resource should be interpreted. <br/>There MAY be exactly 1 <code>sourceDateEnd</code> property per TimeState. The timestamp MUST be expressed in the <code>xsd:dateTime</code> format, and MUST use the UTC timezone expressed as "Z". If <code>sourceDateEnd</code> is provided then <code>sourceDateStart</code> MUST also be provided.</td>
+						<td>The timestamp that ends the interval over which the <a>Source</a> resource should be interpreted. <br/>There MAY be exactly 1 <code>sourceDateEnd</code> property per TimeState. The timestamp MUST be expressed in the <code>xsd:dateTime</code> format, and MUST use the UTC timezone expressed as "Z". If <code>sourceDateEnd</code> is provided then <code>sourceDateStart</code> MUST also be provided.</td>
 					</tr>
 					<tr>
 						<td>cached</td>
 						<td>Relationship</td>
-						<td>A link to a copy of the <p>Source</p> resource's representation, appropriate for the application. <br/>There MAY be 0 or more <code>cached</code> relationships per TimeState. If there is more than 1, each gives an alternative copy of the representation.</td>
+						<td>A link to a copy of the <a>Source</a> resource's representation, appropriate for the application. <br/>There MAY be 0 or more <code>cached</code> relationships per TimeState. If there is more than 1, each gives an alternative copy of the representation.</td>
 					</tr>
 				</table>
 

--- a/index.html
+++ b/index.html
@@ -263,6 +263,8 @@
 				The ability of using a <code>source</code> within a Selector is the <em>only</em> extension to the Selectors as defined by the Web Annotation Model&nbsp;[[annotation-model]]
 			</p>
 
+			<p class=issue data-number=4></p>
+
 
             <p>
 				<b>Example Use Case:</b> Qitara wants to associate a selection of text in a web page with a slice of a dataset.
@@ -906,6 +908,7 @@
 				A <dfn>State</dfn> object is used to describe how to determine the state of interest from within the <a>Source</a> resource. These two entities are encapsulated in a <a>Specific Resource</a>.</p>
 			</p>
 
+			<p class="issue" data-number=3></p>
 
 			<p>
 				<b>Example Use Case:</b> Alexandra visualizes data on a web page that changes frequently. Her client records information to allow other clients to hopefully reconstruct the original visualization.


### PR DESCRIPTION
I have made the following changes

- Improved the examples a little bit
- Realized that we may need an extension to the Selector to include the possibility of using `source`. This is necessary in order to have ranges spreading over constituent resources of a WP. See also #4.
- Created issues and linked them from the document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/publ-loc/examples-source-in-Selectors.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/publ-loc/2e124c2...0077afd.html)