### PR TITLE
Extend Range Selector, add Multi Selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                   	}
               	],
 				otherLinks: [{
-					key: "Authors of the original version",
+					key: "Editors/Authors of the original version",
 					data: [{
 						value: "Ivan Herman, W3C",
 						href: "https://www.w3.org/"
@@ -53,7 +53,7 @@
 						value: "Paulo Ciccarese, Massachusetts General Hospital",
 						href: "http://www.paolociccarese.info"
 					}, {
-						value: "Benjamin Young, John Wiley &amp; Sons, Inc.",
+						value: "Benjamin Young, John Wiley & Sons, Inc.",
 						href: "http://www.wiley.com/"
 					}]
 				}],

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
             <p>
             	Selecting a <em>part of</em> a resource on the Web is an ubiquitous action. Similarly, 
             	referencing a <em>position in</em> 
-            	a resource respresentation is often necessary to support curation of and  discourse about Web resources. 
+            	a resource representation is often necessary to support curation of and  discourse about Web resources. 
 				Interactive editing of a resource, highlighting an area on the screen, adding an annotation to a specific point 
 				in a resource, or defining a bookmark to a location or a section of a long document are all examples that 
 				involve selection or positioning within a resource.</p>
@@ -176,25 +176,33 @@
 				The data model is defined in [[json]], in the form of JSON objects and keys.
 				The formal specification and the semantics of these originate from a larger model, namely the 
 				Web Annotation Data Model&nbsp;[[!annotation-model]], where it is used to select targets of annotations.
-				The current document “extracts” <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> from that data model; 
-        by doing so, it makes their usage easier for applications developers whose concerns are not related to annotations. 
-        Compared to the Web Annotation Data Model, however, this document <em>adds</em> two new selectors, namely:
+				The current document “extracts” <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> from that data model; by doing so, it makes their usage easier for applications developers whose concerns are not related to annotations. 
+				Compared to the Web Annotation Data Model, however, this document <em>adds</em> two new selectors, namely:
 			</p>
 
 			<ul>
 				<li><a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a> can be used to select a full resource, with its a, from a collection of resources, also identified with a URL;</li>
-				<li><a href="#MultipleResourceSelector_def">Multiple Resource Selectors</a> can be used to define a range spanning over a series of resources that are part of the same collection of resources.</li>
+				<li><a href="#MultipleSelector_def">Multiple Selectors</a> identify a collection of discrete selections, whether within the same or spread over several Sources.</li>
+			</ul>
+
+			<p>
+				The document also <em>extends</em> the <a href="#RangeSelector_def">Range Selector</a> by:
+			</p>
+
+			<ul>
+				<li>making explicit that the start and end selectors may refer to different resources;</li>
+				<li>adding a property to define a list of “intermediate” resources for ranges that spread over several of those.</li>
 			</ul>
         	
-        	<p>These new selector types aim at addressing the particular requirements of resource collections on the Web, 
-        		like Web Applications or Web Publications&nbsp;[[wpub]].</p>
+        	<p>
+				These changes aim at addressing the particular requirements of resource collections on the Web, like Web Applications or Web Publications&nbsp;[[wpub]].
+			</p>
         	
         	<p>
-        		Additionally the current document augments the Web Annotation Data Model of selectors and states with
-        		a new class of specifier, <a data-lt="Position">Positions</a>. Two position specifiers are defined:
+        		Additionally the current document augments the Web Annotation Data Model of selectors and states with a new class of specifier, <a data-lt="Position">Positions</a>. Two position specifiers are defined:
         	</p>
         	
-     <ul>
+     		<ul>
 				<li><a href="#TextStreamPosition_def">Text Stream Position</a> can be used to define a position within a text stream representation of a resource.</li>
 				<li><a href="#ByteStreamPosition_def">Byte Stream Position</a> can be used to define a position within a byte stream representation of a resource.</li>
 			</ul>
@@ -219,7 +227,7 @@
 					<dt><dfn>Locator</dfn></dt>
                 	<dd>A <a>Resource</a> that specifies a position in or a portion of another <a>Web Resource</a>. A Locator expresses its relationship to the relevant Web Resource (the <a>Source</a>) through a <code>source</code> term, and MAY express a contextual relationship to an additional <a>Web Resource</a> through a <code>scope</code> term.</dd>
 
-					<dt><dfn>Source</dfn></dt>
+					<dt><dfn data-lt="Sources">Source</dfn></dt>
                 	<dd>The overall <a>Web Resource</a> whose selection is refined through the usage of <a data-lt="Selector">Selector</a>, <a data-lt="Position">Position</a>, or <a data-lt="State">State</a> specifier(s).</dd>
 
 					<dt><dfn data-lt="segment">Segment (of Interest)</dfn></dt>
@@ -303,7 +311,7 @@
             </ol>
 
             <p>
-				A <dfn>Selector</dfn> object is used to describe how to determine the <a>Segment</a> from within the <a>Source</a> resource.
+				A <dfn data-lt="Selectors">Selector</dfn> object is used to describe how to determine the <a>Segment</a> from within the <a>Source</a> resource.
 				The nature of the Selector is dependent on the type of resource, as the methods to describe Segments from various media-types differ. These two entities are encapsulated in a <a>Locator</a>.
 			</p>
 
@@ -329,10 +337,10 @@
             <h4>Example</h4>
 
             <pre class="example highlight" title="Selectors">
-{
-	"source": "http://example.org/page1",
-	"selector": "http://example.org/paraselector1"
-}
+			{
+			  "source": "http://example.org/page1",
+			  "selector": "http://example.org/paraselector1"
+			}
             </pre>
 
             <section id="FragmentSelector_def">
@@ -404,12 +412,12 @@
 
                 <pre class="example highlight" title="Fragment Selector" id="FragmentSelector_ex">
 {
-	"source": "http://example.org/video1",
-	"selector": {
-		"type": "FragmentSelector",
-		"conformsTo": "http://www.w3.org/TR/media-frags/",
-		"value": "t=30,60"
-	}
+  "source": "http://example.org/video1",
+  "selector": {
+    "type": "FragmentSelector",
+    "conformsTo": "http://www.w3.org/TR/media-frags/",
+    "value": "t=30,60"
+  }
 }
                 </pre>
             </section>
@@ -450,16 +458,16 @@
                 	Implementers SHOULD use only commonly supported features of CSS that directly contribute to selection of an element or content, rather than styling or transformation, in order to maximize interoperability between systems.
                 </div>
 
-                <h4>Example</h4>
+                <h4 id="scope_example">Example</h4>
 
                 <pre class="example highlight" title="CSS Selector" id="CssSelector_ex">
 {
-	"scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-	"selector": {
-		"type": "CssSelector",
-		"value": "#elemid > .elemclass + p"
-	}
+  "scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+  "selector": {
+    "type": "CssSelector",
+    "value": "#elemid > .elemclass + p"
+  }
 }
                 </pre>
             </section>
@@ -508,11 +516,11 @@
 
                 <pre class="example highlight" title="XPath Selector" id="XPathSelector_ex">
 {
-	"source": "http://example.org/page1.html",
-	"selector": {
-		"type": "XPathSelector",
-		"value": "/html/body/p[2]/table/tr[2]/td[3]/span"
-	}
+  "source": "http://example.org/page1.html",
+  "selector": {
+    "type": "XPathSelector",
+    "value": "/html/body/p[2]/table/tr[2]/td[3]/span"
+  }
 }
                 </pre>
             </section>
@@ -584,13 +592,13 @@
 
                 <pre class="example highlight" title="Text Quote Selector" id="TextQuoteSelector_ex">
 {
-	"source": "http://example.org/page1",
-	"selector": {
-		"type": "TextQuoteSelector",
-		"exact": "anotation",
-		"prefix": "this is an ",
-		"suffix": " that has some"
-	}
+  "source": "http://example.org/page1",
+  "selector": {
+    "type": "TextQuoteSelector",
+    "exact": "anotation",
+    "prefix": "this is an ",
+    "suffix": " that has some"
+  }
 }
                 </pre>
             </section>
@@ -648,12 +656,12 @@
 
 				<pre class="example highlight" title="Text Position Selector" id="TextPositionSelector_ex">
 {
-	"source": "http://example.org/ebook1",
-	"selector": {
-		"type": "TextPositionSelector",
-		"start": 412,
-		"end": 795
-	}
+  "source": "http://example.org/ebook1",
+  "selector": {
+    "type": "TextPositionSelector",
+    "start": 412,
+    "end": 795
+  }
 }
 	            </pre>
         	</section>
@@ -693,12 +701,12 @@
 
 				<pre class="example highlight" title="Data Position Selector" id="DataPositionSelector_ex">
 {
-	"source": "http://example.org/diskimg1",
-	"selector": {
-		"type": "DataPositionSelector",
-		"start": 4096,
-		"end": 4104
-	}
+  "source": "http://example.org/diskimg1",
+  "selector": {
+    "type": "DataPositionSelector",
+    "start": 4096,
+    "end": 4104
+  }
 }
 				</pre>
         	</section>
@@ -750,153 +758,24 @@
 				<h4>Example</h4>
 
 				<pre class="example highlight" title="SVG Selector" id="SvgSelector_ex_1">
-				{
-					"source": "http://example.org/map1",
-					"selector": {
-						"type": "SvgSelector",
-						"id": "http://example.org/svg1"
-					}
-				}
+{
+  "source": "http://example.org/map1",
+  "selector": {
+    "type": "SvgSelector",
+    "id": "http://example.org/svg1"
+  }
+}
 				</pre>
 
 				<pre class="example highlight" title="SVG Selector, embedded" id="SvgSelector_ex_2">
-				{
-					"source": "http://example.org/map1",
-					"selector": {
-						"type": "SvgSelector",
-						"value": "&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"
-					}
-				}
-				</pre>
-			</section>
-
-			<section id="RangeSelector_def">
-				<h3>Range Selector</h3>
-
-				<p>
-					Selections made by users may be extensive and/or cross over internal boundaries in the representation, making it difficult to construct a single selector that robustly describes the correct content. 
-					A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors.
-					In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection.
-					The selection consists of everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it.
-				</p>
-				
-				<p>
-					<b>Example Use Case:</b> Yadira wants to comment on text in a Web Publication that spreads over several paragraphs.
-					She selects the start and the end of the selection; her User Agent calculates the Range Selector using the first selection as a start and the second selector as the end.
-				</p>
-
-				<h4>Model</h4>
-
-				<table class="model">
-					<tr><th>Term</th><th>Type</th><th>Description</th></tr>
-					<tr>
-						<td>type</td>
-						<td>Relationship</td>
-						<td>The class of the Selector.<br/>Range Selectors MUST have exactly 1 <code>type</code> and the value MUST be <code>RangeSelector</code>.</td>
-					</tr>
-					<tr>
-						<td>startSelector</td>
-						<td>Relationship</td>
-						<td>The Selector which describes the inclusive starting point of the range. <br/>There MUST be exactly 1 <code>startSelector</code> associated with a Range Selector.</td>
-					</tr>
-					<tr>
-						<td>endSelector</td>
-						<td>Relationship</td>
-						<td>The Selector which describes the exclusive ending point of the range. <br/>There MUST be exactly 1 <code>endSelector</code> associated with a Range Selector.  Both <code>startSelector</code> and <code>endSelector</code> SHOULD be of the same class.</td>
-					</tr>
-				</table>
-
-				<h4>Example</h4>
-
-				<pre class="example highlight" title="Range Selector" id="RangeSelector_ex">
 {
-	"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-	"selector": {
-		"type": "RangeSelector",
-		"startSelector": {
-			"type": "TextQuoteSelector",
-			"exact": "Call me Ishmael.",
-			"suffix": "Some years ago"
-		},
-		"endSelector": {
-			"type": "TextQuoteSelector",
-			"exact": "He desires to paint you the dreamiest, ",
-			"prefix": "But here is an artist. ",
-			"suffix": "shadiest, quietest"
-		}
-	}
+  "source": "http://example.org/map1",
+  "selector": {
+    "type": "SvgSelector",
+    "value": "&lt;svg:svg&gt; ... &lt;/svg:svg&gt;"
+  }
 }
 				</pre>
-			</section>
-
-			<section id="MultiResourceSelector_def" class="normative">
-				<h3>Multi Resource Selector</h3>
-
-				<p><em>This section is normative</em></p>
-
-				<p>
-					For some use cases it is required to identify a fragment that spans, possibly, over multiple contiguous members of a group of resources (e.g., a subset in order of the resources which comprise a Web Publication&nbsp;[[!wpub]]). 
-					A Multi Resource Selection can be used to identify this span by creating an ordered list of Locators.
-					The selection consists of everything from the beginning of the starting selector in the first Locator, all selections identified by the intermediate Locators in the list (if any), through to the beginning of the ending selector, but not including it.
-				</p>
-
-				<p class=note>
-					A <a href="#RangeSelector_def">Range Selector</a> may be considered as a special case for a Multi Resource Selector, albeit defined much more succinctly.
-				</p>
-					
-				<p>
-					<b>Example Use Case:</b> Előd wants to comment on a text in a Web Publication that spreads over several resources within the Web Publication.
-					He selects the start and the end of the selection in two different constituent resoruces; his User Agent calculates the Multi Resource Selector using the first selection as a start, the second selector as the end, and the resources listed in the <a href="https://w3c.github.io/wpub/#dfn-default-reading-order" class="externalDFN">default reading order</a> of the Web Publication as intermediate selections.
-				</p>
-
-				<p class=ednote>The reference to the TR version of the WPUB document must be used, when available.</p>
-	
-				<p class=issue data-number=11></p>
-
-				<h4>Model</h4>
-
-				<table class="model">
-					<tr><th>Term</th><th>Type</th><th>Description</th></tr>
-					<tr>
-						<td>type</td>
-						<td>Relationship</td>
-						<td>The class of the Selector.<br/>Range Selectors MUST have exactly 1 <code>type</code> and the value MUST be <code>MultiResourceSelector</code>.</td>
-					</tr>
-					<tr>
-						<td>locators</td>
-						<td>Relationship</td>
-						<td>A list of Locators. <br/>There MUST be exactly 1 <code>locators</code> associated with a Multi Resource Selector.
-							<br/>The list MUST have at least 1 element. 
-						</td>
-					</tr>
-				</table>
-
-				<h4>Example</h4>
-
-				<pre class="example highlight" title="Multi Resource Selector" id="MultiResourceSelector_ex">
-{
-	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"selector": {
-		"type": "MultiResourceSelector",
-		"locators": [{
-			"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-			"selector": {
-				"type": "TextQuoteSelector",
-				"exact": "Call me Ishmael.",
-				"suffix": "Some years ago"                           
-			}
-		},{
-			"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html"
-		},{
-			"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html",
-			"selector": {
-				"type": "TextQuoteSelector",
-				"exact": "The opposite wall of this entry",
-				"suffix": " was hung"                          
-			}
-		}]
-	}    
-}				</pre>
 			</section>
 
 			<section id="EmbeddedResourceSelector_def" class="normative">
@@ -936,92 +815,266 @@
 				<h4>Example</h4>
 				<pre class="example highlight" title="Embedded Resource Selector" id="EmbeddedResourceSelector_ex">
 {
-	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"selector": {
-		"type": "EmbeddedResourceSelector",
-		"value": "https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg"
-	}
+  "source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "selector": {
+    "type": "EmbeddedResourceSelector",
+    "value": "https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg"
+  }
 }				</pre>
-					
-
-
-
-				
 			</section>
 
 			<section id="SelectorRefinement_def">
-				<h3>Refinement of Selection</h3>
+					<h3>Refinement of Selection</h3>
+	
+					<p>
+						It may be easier, more reliable, or more accurate to specify the segment of interest of a resource as a selection of a selection, rather than as a selection of the complete resource.
+						Particularly for resources that contain other resources, such as various packaging formats, this also allows decomposition of the selection mechanisms when the components do not have unique identifiers. 
+						This is accomplished by having selectors chained together, where each refines the results of the previous one.
+					</p>
+	
+					<p>
+						<b>Example Use Case:</b> Zara selects a paragraph of text and then a short phrase within it.
+						Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.
+					</p>
 
+					<div class=note>
+						<p>
+							A frequent usage of refinement is in combination with an <a href="#EmbeddedResourceSelector_def">Embedded Resource Selector</a> to denote the fact that a particular selection is related to, e.g., a Web Publication.
+							For example:
+						</p> 
+
+						<pre class="example highlight">
+{
+  "source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "selector": {
+    "type": "EmbeddedResourceSelector",
+    "value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+    "refinedBy": {
+      "type": "CssSelector",
+      "value": "#elemid > .elemclass + p"
+    }		
+  }
+}
+						</pre>
+
+						<p>
+							For such a simple case, the usage of <code>scope</code> provides for a more succinct way of expressing the same information, see <a href="#scope_example">the example for a CSS Selector</a>. However, when combined with other selectors like, for example, a <a href="#RangeSelector_def">Range Selector</a>, the usage of this pattern becomes essential.
+						</p>
+					</div>
+					
+					<h4>Model</h4>
+	
+					<table class="model">
+					<tr><th>Term</th><th>Type</th><th>Description</th></tr>
+						<tr>
+							<td>refinedBy</td>
+							<td>Relationship</td>
+							<td>The relationship between a broader selector and the more specific selector or position that should be applied to the results of the first. <br/>A Selector MAY be <code>refinedBy</code> 1 or more other <a>Selectors</a> or <a>Positions</a>.  If more than 1 is given, then they are considered to be alternatives that will result in the same selection.</td>
+						</tr>
+					</table>
+	
+					<h4>Examples</h4>
+	
+					<pre class="example highlight" title="Selector Refinement" id="SelectorRefinement_ex">
+{
+  "source": "http://example.org/page1",
+  "selector": {
+    "type": "FragmentSelector",
+    "value": "para5",
+    "refinedBy": {
+      "type": "TextQuoteSelector",
+      "exact": "Selected Text",
+      "prefix": "text before the ",
+      "suffix": " and text after it"
+    }
+  }
+}
+				</pre>
+			</section>
+
+			<section id="RangeSelector_def" class="normative">
+				<h3>Range Selector</h3>
+
+				<p><em>This section is normative</em></p>
+				
 				<p>
-					It may be easier, more reliable, or more accurate to specify the segment of interest of a resource as a selection of a selection, rather than as a selection of the complete resource.
-					Particularly for resources that contain other resources, such as various packaging formats, this also allows decomposition of the selection mechanisms when the components do not have unique identifiers. 
-					This is accomplished by having selectors chained together, where each refines the results of the previous one.
+					Selections made by users may be extensive and/or cross over internal boundaries in the representation, making it difficult to construct a single selector that robustly describes the correct content. 
+					A Range Selector can be used to identify the beginning and the end of the selection by using other Selectors.
+					In this way, two points can be accurately identified using the most appropriate selection mechanisms, and then linked together to form the selection.
+					For some use cases it is also required to identify a range that spans, possibly, over multiple contiguous members of a group of resources (e.g., a subset in order of the resources which comprise a Web Publication&nbsp;[[!wpub]]).
+					A Range Selection MAY therefore spread over several <a>Sources</a>, e.g., through the usage of <a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a>. 
+					The selection consists of:
+				</p>
+				
+				<ul>
+					<li>if both the start and the end selectors refer to the same <a>Source</a>, then everything from the beginning of the starting selector through to the beginning of the ending selector, but not including it;</li>
+					<li>otherwise, everything from the beginning of the starting selector until the end of its <a>Source</a>, all the <a>Sources</a> defined as values of the <code>selectors</code> property (if any), and finally everything from the beginning of the <a>Source</a> of the ending selector to the beginning of the ending selector, but not including it.</li>
+				</ul>
+				
+				<p>
+					<b>Example Use Case:</b> Yadira wants to comment on text in a Web Publication that spreads over several paragraphs.
+					She selects the start and the end of the selection; her User Agent calculates the Range Selector using the first selection as a start and the second selector as the end.
 				</p>
 
 				<p>
-					<b>Example Use Case:</b> Zara selects a paragraph of text and then a short phrase within it.
-					Her client records the phrase as a TextQuoteSelector that further modifies a FragmentSelector used to identify the paragraph that the phrase is part of.
-				</p>
-
-				<p>
-					<b>Example Use Case:</b> Brianne wants to comment on a text in a Web Publication that spreads over two consecutive resources in a Web Publication. 
-					The user agent cannot use the <a href="#RangeSelector_def">Range Selector</a> with, e.g., <a href="#TextQuoteSelector_def">Text Quote Selectors</a> directly, because those Selectors would rely on the same <a>Source</a>. 
-					Instead, Embedded Resource Selectors are used for the start and the end, each using the <a href="#SelectorRefinement_def">Selector Refinement</a> to identify the necessary quote.
+					<b>Example Use Case:</b> Misha wants to comment on text in a Web Publication that spreads over <em>several constituent resources</em>.
+					He selects the start and the end of the selection in different of those resources; his User Agent calculates the Range Selector using a series of Embedded Resource Selections from the first selection as a start and the second selector as the end to provide a continuous range.
 				</p>
 
 				<h4>Model</h4>
 
 				<table class="model">
-				<tr><th>Term</th><th>Type</th><th>Description</th></tr>
+					<tr><th>Term</th><th>Type</th><th>Description</th></tr>
 					<tr>
-						<td>refinedBy</td>
+						<td>type</td>
 						<td>Relationship</td>
-						<td>The relationship between a broader selector and the more specific selector that should be applied to the results of the first. <br/>A Selector MAY be <code>refinedBy</code> 1 or more other Selectors.  If more than 1 is given, then they are considered to be alternatives that will result in the same selection.</td>
+						<td>The class of the Selector.<br/>Range Selectors MUST have exactly 1 <code>type</code> and the value MUST be <code>RangeSelector</code>.</td>
+					</tr>
+					<tr>
+						<td>startSelector</td>
+						<td>Relationship</td>
+						<td>The Selector which describes the inclusive starting point of the range. <br/>There MUST be exactly 1 <code>startSelector</code> associated with a Range Selector.</td>
+					</tr>
+					<tr>
+						<td>selectors</td>
+						<td>Relationship</td>
+						<td>Provides a, possibly empty, list of <a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a>, which define intermediate <a>Sources</a> for the full selection.	
+						<br/>There MAY at most 1 <code>selectors</code> associated with a Range Selector.</td>
+					</tr>					
+					<tr>
+						<td>endSelector</td>
+						<td>Relationship</td>
+						<td>The Selector which describes the exclusive ending point of the range. <br/>There MUST be exactly 1 <code>endSelector</code> associated with a Range Selector.  Both <code>startSelector</code> and <code>endSelector</code> SHOULD be of the same class.</td>
 					</tr>
 				</table>
 
-				<h4>Examples</h4>
+				<h4>Example</h4>
 
-				<pre class="example highlight" title="Selector Refinement" id="SelectorRefinement_ex">
+				<pre class="example highlight" title="Range Selector" id="RangeSelector_ex">
 {
-	"source": "http://example.org/page1",
-	"selector": {
-		"type": "FragmentSelector",
-		"value": "para5",
-		"refinedBy": {
-			"type": "TextQuoteSelector",
-			"exact": "Selected Text",
-			"prefix": "text before the ",
-			"suffix": " and text after it"
-		}
-	}
+  "source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+  "scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "selector": {
+    "type": "RangeSelector",
+    "startSelector": {
+      "type": "TextQuoteSelector",
+      "exact": "Call me Ishmael.",
+      "suffix": "Some years ago"
+    },
+    "endSelector": {
+      "type": "TextQuoteSelector",
+      "exact": "He desires to paint you the dreamiest, ",
+      "prefix": "But here is an artist. ",
+      "suffix": "shadiest, quietest"
+    }
+  }
 }
 				</pre>
 
-				<pre class="example highlight" title="Embedded Resource Selector used with Refinement" id="EmbeddedResourceSelectorRefinement_ex">
+				<pre class="example highlight" title="Range Selector Over Several Resources" id="RangeSelector_ex_1">
 {
-	"source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"selector": {
-		"type": "RangeSelector",
-		"startSelector": {
-			"type": "EmbeddedResourceSelector",
-			"value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-			"refinedBy": {
-				"type": "TextQuoteSelector",
-				"exact": "Call me Ishmael"
-			}
-		},
-		"endSelector": {
-			"type": EmbeddedResourceSelector",
-			"value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html",
-			"refinedBy": {
-				"type": "TextQuoteSelector",
-				"exact": "A hundred black faces turned around"
-			}
-		}
-	}
-}				</pre>
+  "source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "selector": {
+    "type": "RangeSelector",
+    "startSelector": {
+      "type": "EmbeddedResourceSelector",
+      "value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+      "refinedBy" : {
+        "type": "TextQuoteSelector",
+        "exact": "Call me Ishmael.",
+        "suffix": "Some years ago"	
+      }
+    },
+    "selectors": [{
+      "type": "EmbeddedResourceSelector",
+      "value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html",
+    },{
+      "type": "EmbeddedResourceSelector",
+      "value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html",			
+    }],
+    "endSelector": {
+      "type": "EmbeddedResourceSelector",
+      "value": "https://dauwhe.github.io/html-first/MobyDickNav/html/c004.html",
+      "refinedBy": {
+        "type": "TextQuoteSelector",
+        "exact": "He commenced dressing",
+        "suffix": " at top"	
+      }
+    }
+  }
+}
+				</pre>
 			</section>
+
+			<section id="MultiSelector_def" class="normative">
+				<h3>Multi Selector</h3>
+
+				<p><em>This section is normative</em></p>
+
+				<p>
+					For some use cases it is required to identify a fragment that spans, possibly, over multiple members of a group of resources (e.g., a subset in order of the resources which comprise a Web Publication&nbsp;[[!wpub]]). 
+					A Multi Selection can be used to identify this group by creating an ordered list of Selectors.
+					A Multi Selection identifies a collection of discrete selections, whether within the same or spread over several <a>Sources</a>.
+					These selectors MAY be refinements of <a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a>, if the group spawns over several <a>Sources</a>.
+				</p>
+					
+				<p>
+					<b>Example Use Case:</b> Example Use Case: Rachel is writing a summative assessment question with hints pointing back to the textbook. The questions pulls on material presented in Chapter 2, a-head 3, Chapter 4, a-head 6, and in Chapter 7, a-head 8. She uses the Multi Resource Selector defining a single link to add to the hints section of her assessment questions that references Sections 2.3, Section 4.6, and Section 7.8, but nothing in between them. 					
+				</p>
+	
+				<p class=issue data-number=11></p>
+
+				<h4>Model</h4>
+
+				<table class="model">
+					<tr><th>Term</th><th>Type</th><th>Description</th></tr>
+					<tr>
+						<td>type</td>
+						<td>Relationship</td>
+						<td>The class of the Selector.<br/>Range Selectors MUST have exactly 1 <code>type</code> and the value MUST be <code>MultiResourceSelector</code>.</td>
+					</tr>
+					<tr>
+						<td>selectors</td>
+						<td>Relationship</td>
+						<td>A list of Selectors. <br/>There MUST be exactly 1 <code>selectors</code> associated with a Multi  Selector.
+							<br/>The list MUST have at least 1 element. 
+						</td>
+					</tr>
+				</table>
+
+				<h4>Example</h4>
+
+				<pre class="example highlight" title="Multi Selector" id="MultiSelector_ex">
+{
+  "source": "https://textbook.example.org/",
+  "selector": {
+    "type": "MultiSelector",
+    "selectors": [{
+      "type" : "EmbeddedResourceSelector",
+      "value": "https://textbook.example.org/section2.html",
+      "refinedBy": {
+        "type": "CssSelector",
+        "value": "body>section:nth-of-type(3)"
+      }
+    },{
+      "type": "EmbeddedResourceSelector",
+      "value": "https://textbook.example.org/section4.html",
+      "refinedBy": {
+        "type": "CssSelector",
+        "value": "body>section:nth-of-type(6)"
+      }
+    },{
+      "type": "EmbeddedResourceSelector",
+      "value": "https://textbook.example.org/section7.html",
+      "refinedBy": {
+        "type": "CssSelector",
+        "value": "body>section:nth-of-type(8)"
+      }
+    }]
+  }    
+}
+				</pre>
+			</section>			
 		</section> <!-- /Selectors -->
 
 		<section id="states">
@@ -1067,10 +1120,10 @@
 			
 			<pre class="example highlight" title="State">
 {
-	"source": "http://example.org/page1",
-	"state": {
-		"id": "http://example.org/state1"
-	}
+  "source": "http://example.org/page1",
+  "state": {
+    "id": "http://example.org/state1"
+  }
 }
 			</pre>
 			
@@ -1123,12 +1176,12 @@
 				
 				<pre class="example highlight" title="Time State" id="TimeState_ex">
 {
-	"source": "http://example.org/page1",
-	"state": {
-		"type": "TimeState",
-		"cached": "http://archive.example.org/copy1",
-		"sourceDate": "2015-07-20T13:30:00Z"
-	}
+  "source": "http://example.org/page1",
+  "state": {
+    "type": "TimeState",
+    "cached": "http://archive.example.org/copy1",
+    "sourceDate": "2015-07-20T13:30:00Z"
+  }
 }
 				</pre>
 			</section>
@@ -1173,11 +1226,11 @@
 				
 				<pre class="example highlight" title="HTTP Request State" id="HttpRequestState_ex">
 {
-	"source": "http://example.org/resource1",
-	"state": {
-		"type": "HttpRequestState",
-		"value": "Accept: application/pdf"
-	}
+  "source": "http://example.org/resource1",
+  "state": {
+    "type": "HttpRequestState",
+    "value": "Accept: application/pdf"
+  }
 }
 				</pre>
 			</section>
@@ -1217,17 +1270,17 @@
 				<h4>Example</h4>
 				
 				<pre class="example highlight" title="Refinement of States"  id="StateRefinement_ex">
-				{
-					"source": "http://example.org/ebook1",
-					"state": {
-					"type": "TimeState",
-					"sourceDate": "2016-02-01T12:05:23Z",
-						"refinedBy": {
-							"type": "HttpRequestState",
-							"value": "Accept: application/epub+zip"
-						}
-					}
-				}
+{
+  "source": "http://example.org/ebook1",
+  "state": {
+    "type": "TimeState",
+    "sourceDate": "2016-02-01T12:05:23Z",
+    "refinedBy": {
+      "type": "HttpRequestState",
+      "value": "Accept: application/epub+zip"
+    }
+  }
+}
 				</pre>
 			</section>
 		</section> <!-- /States -->
@@ -1236,7 +1289,7 @@
 			<h3>Positions</h3>
 			
 			<p>
-				A <dfn>Position</dfn> object describes a <a>Locus (of Interest)</a> within a stream 
+				A <dfn data-lt="Positions">Position</dfn> object describes a <a>Locus (of Interest)</a> within a stream 
 				representation of a <a>Web Resource</a>. 				
 				</p>
 			
@@ -1275,11 +1328,11 @@
 			
 			<pre class="example highlight" title="Position">
 {
-	"scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-	"position": {
-		"id": "http://example.org/printPageBreak-c1.1"
-	}
+  "scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+  "position": {
+    "id": "http://example.org/printPageBreak-c1.1"
+  }
 }
 			</pre>
 			
@@ -1364,13 +1417,13 @@
 				
 				<pre class="example highlight" title="TextStreamPosition" id="TextStreamPosition_ex">
 {
-	"scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-	"position": {
-		"type": "TextStreamPosition",
-		"value": 322,
-		"bias": "after"
-	}
+  "scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+  "position": {
+    "type": "TextStreamPosition",
+    "value": 322,
+    "bias": "after"
+  }
 }
 				</pre>
 			</section>
@@ -1420,11 +1473,11 @@
 				
 				<pre class="example highlight" title="DataStreamPosition" id="DataStreamPosition_ex">
 {
-	"source": "https://example.org/MyData.json",
-	"position": {
-		"type": "DataStreamPosition",
-		"value": 401
-	}
+  "source": "https://example.org/MyData.json",
+  "position": {
+    "type": "DataStreamPosition",
+    "value": 401
+  }
 }
 				</pre>
 			</section>
@@ -1454,16 +1507,16 @@
 				
 				<pre class="example highlight" title="Refinement by Position Specifier"  id="PositionRefinement_ex">
 {
-	"scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
-	"source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
-	"selector": {
-		"type": "CssSelector",
-		"value": "p:nth-child(2)",
-		"refinedBy": {
-			"type": "TextStreamPosition",
-			"value": 8
-		}		
-	}
+  "scope": "https://dauwhe.github.io/html-first/MobyDick.wpub",
+  "source": "https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html",
+  "selector": {
+    "type": "CssSelector",
+    "value": "p:nth-child(2)",
+    "refinedBy": {
+      "type": "TextStreamPosition",
+      "value": 8
+    }		
+  }
 }
 				</pre>
 			</section>
@@ -1508,7 +1561,8 @@
 						<li>For the key <code>refinedBy</code> the syntax is <code>refinedBy=selector(…)</code>, 
 							<code>refinedBy=position(...)</code>, or <code>refinedBy=state(...)</code>,
 							  with the value following, recursively, the same syntax as a full fragment;</li>
-						<li>For the key <code>locators</code> the content is a comma separated list of locators;</li>
+						<li>For the key <code>selectors</code> the syntax is <code>selectors(…)</code> containing a comma separated list of selectors;</li>
+						<li>For the key <code>scope</code>, <code>scope=url</code> is added to the tope level <code>selector(…)</code>, <code>position(…)</code>, or <code>state(…)</code>, although, strictly speaking, the scope value is set on the overall Locator rather than one of the <a>Specifiers</a>.</li>
 						<li>otherwise the key, and the corresponding value, follows the simple <code>key=value</code> syntax, e.g., <code>type=CssSelector</code>.</li>
 					</ul>
 				</li>
@@ -1560,7 +1614,7 @@
 				<h4>JSON examples converted to fragment identifiers</h4>
 
 				<p>
-					This section contains a mapping of all examples used in the definion of <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> onto full URL-s with fragment identifiers.
+					This section contains a mapping of all examples used in the definition of <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> onto full URL-s with fragment identifiers.
 					Note that the examples below have been broken into several lines for a greater readability; in real usage such new lines are not allowed in a URL.
 				</p>
 
@@ -1571,215 +1625,242 @@
 				<p class="ex_title"><a href="#FragmentSelector_ex">Example</a> for a <a href="#FragmentSelector_def"></a></p>
 				<pre class="example nohighlight" title="Fragment Selector as Fragment" id="FragmentSelector_frag">
 				http://example.org/video1#selector(
-					type=FragmentSelector,
-					conformsTo=http://www.w3.org/TR/media-frags,
-					value=t%3D30%2C60
+				  type=FragmentSelector,
+				  conformsTo=http://www.w3.org/TR/media-frags,
+				  value=t%3D30%2C60
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#CssSelector_ex">Example</a> for a <a href="#CssSelector_def"></a></p>
 				<pre class="example nohighlight" title="CSS Selector as Fragment" id="CssSelector_frag">
 				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-					type=CssSelector,
-					scope=https://dauwhe.github.io/html-first/MobyDick.wpub
-					value=%23elemid%20>%20.elemclass%20+%20p,
+				  type=CssSelector,
+				  scope=https://dauwhe.github.io/html-first/MobyDick.wpub,
+				  value=%23elemid%20>%20.elemclass%20+%20p
 				)				 
 				</pre>
 
 				<p class="ex_title"><a href="#XPathSelector_ex">Example</a> for a <a href="#XPathSelector_def"></a></p>
 				<pre class="example nohighlight" title="XPath Selector as Fragment" id="XPathSelector_frag">
 				http://example.org/page1.html#selector(
-					type=XPathSelector,
-					value=/html/body/p[2]/table/tr[2]/td[3]/span
+				  type=XPathSelector,
+				  value=/html/body/p[2]/table/tr[2]/td[3]/span
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#TextQuoteSelector_ex">Example</a> for a <a href="#TextQuoteSelector_def"></a></p>
 				<pre class="example nohighlight" title="Text Quote Selector as Fragment" id="TextQuoteSelector_frag">
 				http://example.org/page1#selector(
-					type=TextQuoteSelector,
-					exact=annotation,
-					prefix=this%20is%20an%20,
-					suffix=%20that%20has%20some
+				  type=TextQuoteSelector,
+				  exact=annotation,
+				  prefix=this%20is%20an%20,
+				  suffix=%20that%20has%20some
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#TextPositionSelector_ex">Example</a> for a <a href="#TextPositionSelector_def"></a></p>
 				<pre class="example nohighlight" title="Text Position Selector as Fragment" id="TextPositionSelector_frag">
 				http://example.org/ebook1#selector(
-					type=TextPositionSelector,
-					start=412,
-					end=795
+				  type=TextPositionSelector,
+				  start=412,
+				  end=795
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#DataPositionSelector_ex">Example</a> for a <a href="#DataPositionSelector_def"></a></p>
 				<pre class="example nohighlight" title="Data Position Selector as Fragment" id="DataPositionSelector_frag">
 				http://example.org/diskimg1#selector(
-					type=DataPositionSelector,
-					start=4096,
-					end=4104
+				  type=DataPositionSelector,
+				  start=4096,
+				  end=4104
 				)
 				</pre>
 
 				<p class="ex_title">First <a href="#SvgSelector_ex_1">example</a> for a <a href="#SvgSelector_def"></a></p>
 				<pre class="example nohighlight" title="SVG Selector as Fragment, referring to an external SVG" id="SvgSelector_frag_1">
 				http://example.org/map1#selector(
-					type=SvgSelector,
-					id=http://example.org/svg1
+				  type=SvgSelector,
+				  id=http://example.org/svg1
 				)
 				</pre>
 
 				<p class="ex_title">Second <a href="#SvgSelector_ex_2">example</a> for a <a href="#SvgSelector_def"></a></p>
 				<pre class="example nohighlight" title="SVG Selector as Fragment, using embedded SVG" id="SvgSelector_frag_2">
 				http://example.org/map1#selector(
-					type=SvgSelector,
-					value=&lt;svg:svg&gt;%20…%20&lt;/svg:svg&gt;
+				  type=SvgSelector,
+				  value=&lt;svg:svg&gt;%20…%20&lt;/svg:svg&gt;
 				)
 				</pre>
 
-				<p>
+				<p class=note>
 					Please note that long SVG representations will produce very long URLs when produced according to this pattern.
 					Care should be taken in environments where there is a character limit to URLs, and implementers should consider publishing the SVG as a separate resource and using its URL as shown in <a href="#SvgSelector_frag_1">Example 22</a>.
 				</p>
 
-				<p class="ex_title"><a href="#RangeSelector_ex">Example</a> for a <a href="#RangeSelector_def"></a></p>
-				<pre class="example nohighlight" title="Range Selector as Fragment" id="RangeSelector_frag">
-					https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-					type=RangeSelector,
-					startSelector=selector(
-						type=TextQuoteSelector,
-						exact=Call%20me%20Ishmael.,
-						suffix=Some%20years%20ago
-					),
-					startSelector=selector(
-						type=TextQuoteSelector,
-						exact=He%20desires%20to%20paint%20you%20the dreamiest,%20, 
-						prefix=But%20here%20is%20an%20artist.%20, 
-						suffix=shadiest%2C%20quietest
-					)
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#MultiResourceSelector_ex">Example</a> for a <a href="#MultiResourceSelector_def"></a></p>
-				<pre class="example nohighlight" title="Multi Resource Selector as Fragment" id="MultiResourceSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-					type=MultiResourceSelector,
-					selector(
-						source=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html
-						type=TextQuoteSelector,
-						exact=Call%20me%20Ishmael.,
-						suffix=Some%20years%20ago
-					),
-					selector(
-						source=https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html
-					),
-					selector(
-						source=https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html
-						type=TextQuoteSelector,
-						exact=The%20opposite%20wall%20of%20thi%20entry, 
-						suffix=%20was%20hung
-					)
-				)
-				</pre>
-
 				<p class="ex_title"><a href="#EmbeddedResourceSelector_ex">Example</a> for an <a href="#EmbeddedesourceSelector_def"></a></p>
 				<pre class="example nohighlight" title="Embedded Resource Selector as Fragment" id="EmbeddedResourceSelector_frag">
 				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-					type=EmbeddedResourceSelector,
-					value=https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg
+				  type=EmbeddedResourceSelector,
+				  value=https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#SelectorRefinement_ex">Example</a> for a <a href="#SelectorRefinement_def"></a></p>
 				<pre class="example nohighlight" title="Selector Refinement as Fragment" id="SelectorRefinement_frag">
 				http://example.org/page1#selector(
-					type=FragmentSelector,
-					value=para5,
-					refinedBy=selector(
-						type=TextQuoteSelector,exact=Selected%20Text,
-						prefix=text%20before%20the%20,
-						suffix=%20and%20text%20after%20it
-					)
+				  type=FragmentSelector,
+				  value=para5,
+				  refinedBy=selector(
+				    type=TextQuoteSelector,exact=Selected%20Text,
+				    prefix=text%20before%20the%20,
+				    suffix=%20and%20text%20after%20it
+				  )
 				)
 				</pre>
 
-				<p class="ex_title"><a href="#EmbeddedResourceSelectorRefinement_ex">Example</a> for a <a href="#SelectorRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Embedded Resource Selector Refined in a Range Selector" id="EmbeddedResourcSelectorRefinement_frag">
+				<p class="ex_title"><a href="#RangeSelector_ex">Example</a> for a <a href="#RangeSelector_def"></a></p>
+				<pre class="example nohighlight" title="Range Selector as Fragment" id="RangeSelector_frag">
+				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
+				  type=RangeSelector,
+				  startSelector=selector(
+				    type=TextQuoteSelector,
+				    exact=Call%20me%20Ishmael.,
+				    suffix=Some%20years%20ago
+				  ),
+				  startSelector=selector(
+				    type=TextQuoteSelector,
+				      exact=He%20desires%20to%20paint%20you%20the%20dreamiest,%20, 
+				      prefix=But%20here%20is%20an%20artist.%20, 
+				      suffix=shadiest%2C%20quietest
+				  )
+				)
+				</pre>
+
+				<p class="ex_title"><a href="#RangeSelector_ex_1">Example</a> for a <a href="#RangeSelector_def"></a> Over Several Resources</p>
+				<pre class="example nohighlight" title="Range Selector Over Several Resourcest" id="RangeSelector_frag_1">
 				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-					type=RangeSelector,
-					startSelector=selector(
-						type=EmbeddedResourceSelector,
-						value=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html
-						refinedBy=selector(
-							type=TextQuoteSelector,
-							exact=Call%20me%20Ishmael.
-						)
-					),
-					endSelector= selector(
-						type=EmbeddedResourceSelector,
-						value=https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html
-						refinedBy=selector(
-							type=TextQuoteSelector,
-							exact=A%20hundred%20black%20faces%20turned%20around, 									
-						)
-					)
+				  type=RangeSelector,
+				  startSelector=selector(
+				    type=EmbeddedResourceSelector,
+				    value=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
+				    refinedBy=selector(
+				      type=TextQuoteSelector,
+				      exact=Call%20me%20Ishmael.,
+				      suffix=Some%20years%20ago
+				    )
+				  ),
+				  selectors(
+				    selector(
+				      type=EmbeddedResourceSelector,
+				      value=https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html						
+				    ),
+				    selector(
+				      type=EmbeddedResourceSelector,
+				      value=https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html						
+				    )	
+				  ),
+				  endSelector=selector(
+				    type=EmbeddedResourceSelector,
+				    value=https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html,
+				    refinedBy=selector(
+				      type=TextQuoteSelector,
+				      exact=He%20commenced%20dressing,
+				      suffix=%20at%top
+				    )
+				  )
+				)
+				</pre>
+
+				<p class="ex_title"><a href="#MultiSelector_ex">Example</a> for a <a href="#MultiSelector_def"></a></p>
+				<pre class="example nohighlight" title="Multi Selector as Fragment" id="MultiSelector_frag">
+				https://textbook.example.org#selector(
+				  type=MultiSelector,
+				  selectors(
+				    selector(
+				      type=EmbeddedResourceSelector,
+				      value=https://textbook.example.org/section2.html,
+				      refinedBy=selector(
+				        type=CssSelector,
+				        value=body>section:nth-of-type(3)
+				      )
+				    ),
+				    selector(
+				      type=EmbeddedResourceSelector,
+				      value=https://textbook.example.org/section4.html
+				      refinedBy=selector(
+				        type=CssSelector,
+				        value=body>section:nth-of-type(6)
+				      )
+				    ),
+				    selector(
+				      type=EmbeddedResourceSelector,
+				      value=https://textbook.example.org/section7.html
+				      refinedBy=selector(
+				        type=CssSelector,
+				        value=body>section:nth-of-type(8)
+				      )
+				    )
+				  )
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#TimeState_ex">Example</a> for a <a href="#TimeState_def"></a></p>
 				<pre class="example nohighlight" title="Time State as Fragment" id="TimeState_frag">
 				http://example.org/page1#state(
-					type=TimeState,
-					cached=http://archive.example.org/copy1,
-					sourceDate=2015-07-20T13:30:00Z
+				  type=TimeState,
+				  cached=http://archive.example.org/copy1,
+				  sourceDate=2015-07-20T13:30:00Z
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#HttpRequestState_ex">Example</a> for a <a href="#HttpRequestState_def"></a></p>
 				<pre class="example nohighlight" title="HTTP Request State as Fragment" id="HttpRequestState_frag">
 				http://example.org/resource1#state(
-					type=HttpRequestState,
-					value=Accept:%20application/pdf
+				  type=HttpRequestState,
+				  value=Accept:%20application/pdf
 				)
 				</pre>
 
 				<p class="ex_title"><a href="#StateRefinement_def">Example</a> for a <a href="#StateRefinement_def"></a></p>
 				<pre class="example nohighlight" title="Refinement of States as Fragment" id="StateRefinement_frag">
 				http://example.org/ebook1#state(
-					type=TimeState,sourceDate=2016-02-01T12:05:23Z,
-					refinedBy=state(
-					type=HttpRequestState,
-					value=Accept:%20application/epub+zip
-					)
+				  type=TimeState,sourceDate=2016-02-01T12:05:23Z,
+				  refinedBy=state(
+				    type=HttpRequestState,
+				    value=Accept:%20application/epub+zip
+				  )
 				)
 				</pre>
 				
 				<p class="ex_title">Example for a <a href="#TextStreamPosition_def"></a></p>
 				<pre class="example nohighlight" title="Text Stream Position as Fragment" id="TextStreamPosition_frag">
 				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#position(
-					type=TextStreamPosition,value=322,bias=after
+				  type=TextStreamPosition,
+				  value=322,
+				  bias=after
 				)
 				</pre>				
 
 				<p class="ex_title">Example for a <a href="#DataStreamPosition_def"></a></p>
 				<pre class="example nohighlight" title="Data Stream Position as Fragment" id="DataStreamPosition_frag">
 				https://example.org/MyData.json#position(
-					type=DataStreamPosition,value=401
+				  type=DataStreamPosition,
+				  value=401
 				)
 				</pre>	
 				
 				<p class="ex_title">Example for a <a href="#PositionRefinement_def"></a></p>
 				<pre class="example nohighlight" title="Text Stream Position Refinement of CssSelector as Fragment" id="PositionRefinement_frag">
 				https://example.org/MyData.json#selector(
-					type=CssSelector,value=p:nth-child(2),
-					refinedBy=position(type=TextStreamPosition,value=8)
+				  type=CssSelector,
+				  value=p:nth-child(2),
+				  refinedBy=position(
+				    type=TextStreamPosition,
+				    value=8	
+				  )
 				)
 				</pre>	
-				
 			</section>
-
-
 
 			<!-- <section>
 				<h4>Serializing IRI to URL</h4>
@@ -2073,18 +2154,23 @@
 				<p><strong>Non-editorial Changes</strong></p>
 				<ul>
 					<li>
-						The <a href="#locators"><code>scope</code> relationship</a> has re-introduced. (This relationship is part of the “Web Annotation Data Model”&nbsp;[[annotation-model]] but was not retained in the “Selectors and States”&nbsp;[[selectors-states]] Note.)
+						The <a href="#locators"><code>scope</code> relationship</a> has been re-introduced. (This relationship is part of the “Web Annotation Data Model”&nbsp;[[annotation-model]] but was not retained in the “Selectors and States”&nbsp;[[selectors-states]] Note.)
 					</li>
 
 					<li>
 						Two new Selectors have been added, namely
 						<ul>
-							<li>
-								<a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a> can be used to select a full resource, with its a, from a collection of resources, also identified with a URL;
-							</li>
-							<li>
-								<a href="#MultipleResourceSelector_def">Multiple Resource Selectors</a> can be used to define a range spanning over a series of resources that are part of the same collection of resources.
-							</li>
+							<li><a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a> can be used to select a full resource, with its a, from a collection of resources, also identified with a URL;</li>
+							<li><a href="#MultipleSelector_def">Multiple Selectors</a> identify a collection of discrete selections, whether within the same or spread over several Sources.</li>
+						</ul>
+					</li>
+
+					<li>
+						The <a href="#RangeSelector_def">Range Selector</a> has been extended by:
+
+						<ul>
+							<li>making explicit that the start and end selectors may refer to different resources;</li>
+							<li>adding a property to define a list of “intermediate” resources for ranges that spread over several of those.</li>
 						</ul>
 					</li>
 					
@@ -2109,12 +2195,11 @@
 				<tr><td>end</td><td><a href="#TextPositionSelector_def">Text Position Selector</a>, <a href="#DataPositionSelector_def">Data Position Selector</a></td></tr>
 				<tr><td>endSelector</td><td><a href="#RangeSelector_def">Range Selector</a></td></tr>
 				<tr><td>exact</td><td><a href="#TextQuoteSelector_def">Text Quote Selector</a></td></tr>
-				<tr><td>locators</td><td><a href="#MultiResourceSelector_def">Multi Resource Selector</a></td></tr>				
 				<tr><td>position</td><td><a>Locator</a></td></tr>
 				<tr><td>prefix</td><td><a href="#TextQuoteSelector_def">Text Quote Selector</a></td></tr>
 				<tr><td>refinedBy</td><td><a href="#PositionRefinement_def">Position</a>, <a href="#SelectorRefinement_def">Selector</a>, <a href="#StateRefinement_def">State</a></td></tr>
 				<tr><td>selector</td><td><a>Locator</a></td></tr>
-				<tr><td>scope</td><td><a>Locator</a></td></tr>
+				<tr><td>selectors</td><td><a href="#MultiSelector_def">Multi Selector</a>, <a href="#RangeSelector_def">Range Selector</a></td></tr>	<tr><td>scope</td><td><a>Locator</a></td></tr>
 				<tr><td>source</td><td><a>Locator</a></td></tr>				
 				<tr><td>sourceDate</td><td><a href="#TimeState_def">Time State</a></td></tr>
 				<tr><td>sourceDateEnd</td><td><a href="#TimeState_def">Time State</a></td></tr>
@@ -2123,7 +2208,7 @@
 				<tr><td>startSelector</td><td><a href="#RangeSelector_def">Range Selector</a></td></tr>
 				<tr><td>state</td><td><a href="#states">Locator</a></td></tr>
 				<tr><td>suffix</td><td><a href="#TextQuoteSelector_def">Text Quote Selector</a></td></tr>
-				<tr><td class="top_cell">type</td><td><a>Locator</a>, <a href="#FragmentSelector_def">Fragment Selector</a>, <a href="#CssSelector_def">CSS Selector</a>, <a href="#XPathSelector_def">XPath Selector</a>, <a href="#TextQuoteSelector_def">Text Quote Selector</a>, <a href="#TextPositionSelector_def">Text Position Selector</a>, <a href="#DataPositionSelector_def">Data Position Selector</a>, <a href="#SvgSelector_def">SVG Selector</a>, <a href="#EmbeddedResourceSelector_def">Embedded Reosource Selector</a>, <a href="#MultipleResourceSelector_def">Multiple Resource Selector</a>, <a href="#TimeState_def">Time State</a>, <a href="#HttpRequestState_def">Request Header State</a>, <a href="#TextStreamPosition_def">Text Stream Position</a>, <a href="#DataStreamPosition_def">Data Stream Position</a></tr>
+				<tr><td class="top_cell">type</td><td><a>Locator</a>, <a href="#FragmentSelector_def">Fragment Selector</a>, <a href="#CssSelector_def">CSS Selector</a>, <a href="#XPathSelector_def">XPath Selector</a>, <a href="#TextQuoteSelector_def">Text Quote Selector</a>, <a href="#TextPositionSelector_def">Text Position Selector</a>, <a href="#DataPositionSelector_def">Data Position Selector</a>, <a href="#SvgSelector_def">SVG Selector</a>, <a href="#EmbeddedResourceSelector_def">Embedded Resource Selector</a>, <a href="#MultipleSelector_def">Multiple Selector</a>, <a href="#TimeState_def">Time State</a>, <a href="#HttpRequestState_def">Request Header State</a>, <a href="#TextStreamPosition_def">Text Stream Position</a>, <a href="#DataStreamPosition_def">Data Stream Position</a></tr>
 				<tr><td>value</td><td><a href="#FragmentSelector_def">Fragment Selector</a>, <a href="#CssSelector_def">CSS Selector</a>, <a href="#SvgSelector_def">SVG Selector</a>, <a href="#XPathSelector_def">XPath Selector</a>, <a href="#EmbeddedResourceSelector_def">Embedded Resource Selector</a>, <a href="#HttpRequestState_def">Request Header State</a>, <a href="#TextStreamPosition_def">Text Stream Position</a>, <a href="#DataStreamPosition_def">Data Stream Position</a> </td></tr>
 			</table>
 		</section>
@@ -2131,7 +2216,7 @@
 		<section>
 			<h3>Relationships to the Web Annotation Model</h3>
 
-			<p class="ednote">Just a placeholder for now; once the specification is, overall, complete, a section should come to summarize the exact relationships to the Web Annotation Model, the relationships in the conformance of the two standards, etc.</p>
+			<p class="ednote">This is just a placeholder for now; once the specification is, overall, complete, a section should come to summarize the exact relationships to the Web Annotation Model, the relationships in the conformance of the two standards, etc.</p>
 		</section>
 
 		<section class=appendix id="issue-summary"></section>


### PR DESCRIPTION
@tcole3 @BigBlueHat,

I had some empty time today, so I created this PR. It is based on my [thoughts on what we had so far](https://gist.github.com/iherman/65254a9e914de0af319a6800936af39e), and I believe that this design covers the use cases, namely:

- Range that spreads over several resources (by extending the Range Selector)
- Selection of a series of other, disjoint selections (cf. the example of @RachelComerford).

It also seems to be semantically clean, avoiding some issues in my [comments](https://gist.github.com/iherman/65254a9e914de0af319a6800936af39e).

It required quite a number of changes on the document (see the list of changes below) so, I'm afraid, the diff file does not really make sense. But the preview might be fine.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/publ-loc/extend-range-and-co.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/publ-loc/acd1ffe...98833c0.html)