### PR TITLE
Narrow Scope of Fragment Ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,26 @@
                     	"companyURL": "http://www.w3.org",
                   	}
               	],
+        localBiblio: [{
+        "cfi":
+	        {
+	          "authors": [
+	            "Peter Sorotokin",
+	            "Garth Conboy",
+	            "Brady Duga",
+	            "John Rivlin",
+	            "Don Beaver",
+	            "Kevin Ballard",
+	            "Alastair Fettes",
+	            "Daniel Weck"
+	          ],
+	          "title": "EPUB Canonical Fragment Identifiers",
+	          "href": "http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html",
+	          "publisher": "IDPF",
+	          "rawDate": "2014-06-26",
+	          "status": "Recommended Specification"
+	        }        
+        }],      	
 				otherLinks: [{
 					key: "Editors/Authors of the original version",
 					data: [{
@@ -1115,7 +1135,7 @@
 
 				<h4>Example</h4>
 
-				<pre class="example highlight" title="Multi Selector" id="MultiSelector_ex">
+				<pre class="example highlight" title="Multi Resource Selector" id="MultiResourceSelector_ex">
 {
   "source": "https://textbook.example.org/",
   "selector": {
@@ -1579,37 +1599,43 @@
 		</section> <!-- /Position -->
 
 		<section id="frags">
-			<h3>Selectors, Positions, and States as Fragment Identifiers</h3>
-
-			<p>
-				Although <a data-lt="Selector">Selectors</a>, <a data-lt="Position">Positions</a>, and <a data-lt="State">States</a> provide a flexible way of identifying, e.g., a suitable <a>Segment</a> of a Resource, the fact that this is defined through an indirection using a <a>Locator</a> may be an obstacle for some applications. 
-			</p>
+			<h3>Serialization of new Selectors as Fragment Identifiers</h3>
 
 			<p class="ednote">
-				We must add a good example. The original one referred to RDF, which is not relevant in this context.
+				If we decide to define a media type for PWPub (and/or WPub) resources, we will keep this section and update examples and illustrations
+				using file extension associated with this new media type (i.e., the pwpub file extension is a placeholder). Otherwise this section likely will be deleted. 
+				Selectors and States Note used an initial example for fragment identifiers that referred to RDF, which is no longer relevant in this context and 
+				so was not carried over. We possibly may need to replace if we keep this section.
 			</p>
 			
 			<p class="issue" data-number="6"></p>
 
 			<p>
-				To mitigate this issue, a mapping of <a data-lt="Selector">Selectors</a>, <a data-lt="Position">Positions</a>,
-				and <a data-lt="State">States</a> on URL fragments&nbsp;[[url]] is defined below. 
-				As a result of this mapping the selected <a>Segment</a>, targeted <a>Locus</a>, or relevant <a>State</a> is expressed in a 
-				single (albeit complex) URL.
-				In that URL the <a>Selector</a>, <a>Position</a>, or <a>State</a> is expressed as a 
-				single string and serves 
-				as a fragment which can be combined with the URL of the <a>Source</a>. 
-				Note that this representation is valid only if the URL for the <a>Source</a> does not contain a fragment 
-				identifier of its own (a URL may contain at most one fragment identification).
+				The three new types of <a data-lt="Selector">Selectors</a> introduced in this specification, 
+				the <a href="#EmbeddedResourceSelector_def">Embedded Resource Selector</a>, 
+				the <a href="#SpanSelector_def">Span Selector</a>, and 
+				the <a href="#MultiResourceSelector_def">Multi Resource Selector</a>, are applicable exclusively to 
+				resources (identified by a URL) that are collections or groups of other resources. For resources of this type 
+				which have their own distinctive media-type, e.g. a Packaged Web Publication [[pwpub]], it may be more convenient or consistent 
+				with past practice to express these	3 selectors as fragment identifiers&nbsp;[[url]] that can be appended to the url of the collective resource.
+				(An informative precedent for this is the International Digital Publishing Forum Recommended Specification, 
+				<em>EPUB Canonical Fragment Identifiers 1.1</em>&nbsp;[[cfi]], which defines a fragment identifer-serialized model for 
+				selecting and positioning	within resources of the	<code>application/epub+zip</code> media type.) 
+			</p>
+		  <p>
+		  	A mapping of Embedded Resource, Span, and Multi Resource Selectors to URL fragments&nbsp;[[url]] is defined below. 
+				This mapping allows the <a>Segment (of interest)</a> to be expressed in a	single (albeit complex) URL.
+				Note that this representation is valid only if the URL for the <a>Source</a> (the collective resource) does not contain a fragment 
+				identifier of its own (a URL may contain at most one fragment identifier).
 			</p>
 
 			<p>
-				The syntax for mapping a <a>Selector</a>, <a>Position</a>, or <a>State</a> follows the same, “functional” syntax as used, 
-				for example, by the XPointer Framework&nbsp;[[xptr-framework]]:
+				The syntax for mapping the 3 <a>Selector</a> specifiers enumerated above, or any <a>Selector</a>, <a>Position</a>, or <a>State</a> specifier when used to refine, 
+				follows the same, “functional” syntax as used,	for example, by the XPointer Framework&nbsp;[[xptr-framework]]:
 			</p>
 
 			<ul>
-				<li>The fragment uses the <code>selector(…)</code>, <code>position(...)</code>, or <code>state(…)</code> functional syntax.</li>
+				<li>The fragment serialization uses a <code>selector(…)</code>, <code>position(...)</code>, or <code>state(…)</code> functional syntax.</li>
 				<li>The (comma separated) “parameters” of the functional notation are:
 					<ul>
 						<li>For the keys <code>startSelector</code> and <code>endSelector</code> the syntax is <code>key=selector(…)</code>,
@@ -1618,7 +1644,10 @@
 							<code>refinedBy=position(...)</code>, or <code>refinedBy=state(...)</code>,
 							  with the value following, recursively, the same syntax as a full fragment;</li>
 						<li>For the key <code>selectors</code> the syntax is <code>selectors(…)</code> containing a comma separated list of selectors;</li>
-						<li>For the key <code>scope</code>, <code>scope=url</code> is added to the top level <code>selector(…)</code>, <code>position(…)</code>, or <code>state(…)</code>, although, strictly speaking, the scope value is set on the overall Locator rather than one of the <a>Specifiers</a>.</li>
+						<li>The URL to which the fragment identifier is appended is taken as the <code>source</code> for the <code>locator</code>,
+							  so the key <code>source</code> is not mapped and is not allowed in this serialization.</li>
+						<li>The key <code>scope</code> is not mapped and is not allowed in this serialization	since, 
+							  strictly speaking, the <code>scope</code> is a property of a <a>Locator</a> rather than a <a>Specifier</a>.</li>
 						<li>otherwise the key, and the corresponding value, follows the simple <code>key=value</code> syntax, e.g., <code>type=CssSelector</code>.</li>
 					</ul>
 				</li>
@@ -1656,19 +1685,30 @@
 				</tbody>
 			</table>
 
+      <p class="note">
+      	Be aware that because Selectors can be recursively refined, the mapping below can lead to arbitrarily long fragements which may exceed the 
+      	fragment identifier lengths supported	by some User Agents. 
+      </p>
+
 			<div class="note">
 				<p>
-					A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section should be registered for each media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
-					Until such a registration is done, these fragment identifiers have the potential to conflict with other fragments possibly specified by the media type registrations.
-					Consequently, this pattern should only be used when the implementation cannot produce or manage the full representation described above. 
+					A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section 
+					should be registered for each relevant media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
+					Until such a registration is done, these fragment identifiers have the potential to conflict with other fragment identifier schemes specified by media type registrations.
+					Consequently, this pattern should only be used when appending to the URL of a resource of a media-type for which this class of fragment identifer has been registered. 
 				</p>
 			</div>
 
 			<section>
 				<h4>JSON examples converted to fragment identifiers</h4>
 
+        <p class="ednote">
+        	For PWP, relative addressing will likely be important. Can we update these examples to use relative addressing for embedded resources?
+        </p>
+
 				<p>
-					This section contains a mapping of all examples used in the definition of <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> onto full URL-s with fragment identifiers.
+					This section contains a mapping of the examples used in the definitions of <a href="#EmbeddedResourceSelector_def">Embedded Resource Selector</a>, 
+					<a href="#SpanSelector_def">Span Selector</a>, and <a href="#MultiResourceSelector_def">Multi Resource Selector</a>.
 					Note that the examples below have been broken into several lines for a greater readability; in real usage such new lines are not allowed in a URL.
 				</p>
 
@@ -1676,124 +1716,30 @@
 					A <a href="http://w3c.github.io/web-annotation/selector-note/converter/">simple converter tool</a> is also available to test the conversion of the JSON format to fragment and back.
 				</p> -->
 
-				<p class="ex_title"><a href="#FragmentSelector_ex">Example</a> for a <a href="#FragmentSelector_def"></a></p>
-				<pre class="example nohighlight" title="Fragment Selector as Fragment" id="FragmentSelector_frag">
-				http://example.org/video1#selector(
-				  type=FragmentSelector,
-				  conformsTo=http://www.w3.org/TR/media-frags,
-				  value=t%3D30%2C60
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#CssSelector_ex">Example</a> for a <a href="#CssSelector_def"></a></p>
-				<pre class="example nohighlight" title="CSS Selector as Fragment" id="CssSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-				  type=CssSelector,
-				  scope=https://dauwhe.github.io/html-first/MobyDick.wpub,
-				  value=%23elemid%20>%20.elemclass%20+%20p
-				)				 
-				</pre>
-
-				<p class="ex_title"><a href="#XPathSelector_ex">Example</a> for a <a href="#XPathSelector_def"></a></p>
-				<pre class="example nohighlight" title="XPath Selector as Fragment" id="XPathSelector_frag">
-				http://example.org/page1.html#selector(
-				  type=XPathSelector,
-				  value=/html/body/p[2]/table/tr[2]/td[3]/span
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#TextQuoteSelector_ex">Example</a> for a <a href="#TextQuoteSelector_def"></a></p>
-				<pre class="example nohighlight" title="Text Quote Selector as Fragment" id="TextQuoteSelector_frag">
-				http://example.org/page1#selector(
-				  type=TextQuoteSelector,
-				  exact=annotation,
-				  prefix=this%20is%20an%20,
-				  suffix=%20that%20has%20some
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#TextPositionSelector_ex">Example</a> for a <a href="#TextPositionSelector_def"></a></p>
-				<pre class="example nohighlight" title="Text Position Selector as Fragment" id="TextPositionSelector_frag">
-				http://example.org/ebook1#selector(
-				  type=TextPositionSelector,
-				  start=412,
-				  end=795
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#DataPositionSelector_ex">Example</a> for a <a href="#DataPositionSelector_def"></a></p>
-				<pre class="example nohighlight" title="Data Position Selector as Fragment" id="DataPositionSelector_frag">
-				http://example.org/diskimg1#selector(
-				  type=DataPositionSelector,
-				  start=4096,
-				  end=4104
-				)
-				</pre>
-
-				<p class="ex_title">First <a href="#SvgSelector_ex_1">example</a> for a <a href="#SvgSelector_def"></a></p>
-				<pre class="example nohighlight" title="SVG Selector as Fragment, referring to an external SVG" id="SvgSelector_frag_1">
-				http://example.org/map1#selector(
-				  type=SvgSelector,
-				  id=http://example.org/svg1
-				)
-				</pre>
-
-				<p class="ex_title">Second <a href="#SvgSelector_ex_2">example</a> for a <a href="#SvgSelector_def"></a></p>
-				<pre class="example nohighlight" title="SVG Selector as Fragment, using embedded SVG" id="SvgSelector_frag_2">
-				http://example.org/map1#selector(
-				  type=SvgSelector,
-				  value=&lt;svg:svg&gt;%20…%20&lt;/svg:svg&gt;
-				)
-				</pre>
-
-				<p class=note>
-					Please note that long SVG representations will produce very long URLs when produced according to this pattern.
-					Care should be taken in environments where there is a character limit to URLs, and implementers should consider publishing the SVG as a separate resource and using its URL as shown in <a href="#SvgSelector_frag_1">Example 22</a>.
-				</p>
-
-				<p class="ex_title"><a href="#EmbeddedResourceSelector_ex">Example</a> for an <a href="#EmbeddedesourceSelector_def"></a></p>
+				<p class="ex_title"><a href="#EmbeddedResourceSelector_ex">Example</a> for <a href="#EmbeddedResourceSelector_def"></a></p>
 				<pre class="example nohighlight" title="Embedded Resource Selector as Fragment" id="EmbeddedResourceSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
+				https://dauwhe.github.io/html-first/MobyDick.pwpub#selector(
 				  type=EmbeddedResourceSelector,
 				  value=https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg
 				)
 				</pre>
 
-				<p class="ex_title"><a href="#SelectorRefinement_ex">Example</a> for a <a href="#SelectorRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Selector Refinement as Fragment" id="SelectorRefinement_frag">
-				http://example.org/page1#selector(
-				  type=FragmentSelector,
-				  value=para5,
+				<p class="ex_title"><a href="#RefinedEmbeddedResourceSelector_ex">Refinement Example</a> for <a href="#EmbeddedResourceSelector_def"></a></p>
+				<pre class="example nohighlight" title="Refined Embedded Resource Selector as Fragment" id="RefinedEmbeddedResourceSelector_frag">
+				https://dauwhe.github.io/html-first/MobyDick.pwpub#selector(
+				  type=EmbeddedResourceSelector,
+				  value=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
 				  refinedBy=selector(
-				    type=TextQuoteSelector,exact=Selected%20Text,
-				    prefix=text%20before%20the%20,
-				    suffix=%20and%20text%20after%20it
+				  	type=CssSelector,
+				  	value=%23elemid%3E%2Eelemclass%2Bp
+				  	)
 				  )
-				)
 				</pre>
 
-				<p class="ex_title"><a href="#RangeSelector_ex">Example</a> for a <a href="#RangeSelector_def"></a></p>
-				<pre class="example nohighlight" title="Range Selector as Fragment" id="RangeSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-				  type=RangeSelector,
-				  startSelector=selector(
-				    type=TextQuoteSelector,
-				    exact=Call%20me%20Ishmael.,
-				    suffix=Some%20years%20ago
-				  ),
-				  startSelector=selector(
-				    type=TextQuoteSelector,
-				      exact=He%20desires%20to%20paint%20you%20the%20dreamiest,%20, 
-				      prefix=But%20here%20is%20an%20artist.%20, 
-				      suffix=shadiest%2C%20quietest
-				  )
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#RangeSelector_ex_1">Example</a> for a <a href="#RangeSelector_def"></a> Over Several Resources</p>
-				<pre class="example nohighlight" title="Range Selector Over Several Resourcest" id="RangeSelector_frag_1">
-				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-				  type=RangeSelector,
+				<p class="ex_title"><a href="#SpanSelector_ex_1">Example</a> for a <a href="#SpanSelector_def"></a></p>
+				<pre class="example nohighlight" title="Span Selector Over Several Resources" id="SpanSelector_frag_1">
+				https://dauwhe.github.io/html-first/MobyDick.pwpub#selector(
+				  type=SpanSelector,
 				  startSelector=selector(
 				    type=EmbeddedResourceSelector,
 				    value=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
@@ -1819,23 +1765,23 @@
 				    refinedBy=selector(
 				      type=TextQuoteSelector,
 				      exact=He%20commenced%20dressing,
-				      suffix=%20at%top
+				      suffix=%20at%20top
 				    )
 				  )
 				)
 				</pre>
 
-				<p class="ex_title"><a href="#MultiSelector_ex">Example</a> for a <a href="#MultiSelector_def"></a></p>
-				<pre class="example nohighlight" title="Multi Selector as Fragment" id="MultiSelector_frag">
+				<p class="ex_title"><a href="#MultiResourceSelector_ex">Example</a> for a <a href="#MultiResourceSelector_def"></a></p>
+				<pre class="example nohighlight" title="Multi Resource Selector as Fragment" id="MultiResourceSelector_frag">
 				https://textbook.example.org#selector(
-				  type=MultiSelector,
+				  type=MultiResourceSelector,
 				  selectors(
 				    selector(
 				      type=EmbeddedResourceSelector,
 				      value=https://textbook.example.org/section2.html,
 				      refinedBy=selector(
 				        type=CssSelector,
-				        value=body>section:nth-of-type(3)
+				        value=body%3Esection%3Anth-of-type%283%29
 				      )
 				    ),
 				    selector(
@@ -1843,7 +1789,7 @@
 				      value=https://textbook.example.org/section4.html
 				      refinedBy=selector(
 				        type=CssSelector,
-				        value=body>section:nth-of-type(6)
+				        value=body%3Esection%3Anth-of-type%286%29
 				      )
 				    ),
 				    selector(
@@ -1851,69 +1797,12 @@
 				      value=https://textbook.example.org/section7.html
 				      refinedBy=selector(
 				        type=CssSelector,
-				        value=body>section:nth-of-type(8)
+				        value=body%3Esection%3Anth-of-type%288%29
 				      )
 				    )
 				  )
 				)
 				</pre>
-
-				<p class="ex_title"><a href="#TimeState_ex">Example</a> for a <a href="#TimeState_def"></a></p>
-				<pre class="example nohighlight" title="Time State as Fragment" id="TimeState_frag">
-				http://example.org/page1#state(
-				  type=TimeState,
-				  cached=http://archive.example.org/copy1,
-				  sourceDate=2015-07-20T13:30:00Z
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#HttpRequestState_ex">Example</a> for a <a href="#HttpRequestState_def"></a></p>
-				<pre class="example nohighlight" title="HTTP Request State as Fragment" id="HttpRequestState_frag">
-				http://example.org/resource1#state(
-				  type=HttpRequestState,
-				  value=Accept:%20application/pdf
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#StateRefinement_def">Example</a> for a <a href="#StateRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Refinement of States as Fragment" id="StateRefinement_frag">
-				http://example.org/ebook1#state(
-				  type=TimeState,sourceDate=2016-02-01T12:05:23Z,
-				  refinedBy=state(
-				    type=HttpRequestState,
-				    value=Accept:%20application/epub+zip
-				  )
-				)
-				</pre>
-				
-				<p class="ex_title">Example for a <a href="#TextStreamPosition_def"></a></p>
-				<pre class="example nohighlight" title="Text Stream Position as Fragment" id="TextStreamPosition_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#position(
-				  type=TextStreamPosition,
-				  value=322,
-				  bias=after
-				)
-				</pre>				
-
-				<p class="ex_title">Example for a <a href="#DataStreamPosition_def"></a></p>
-				<pre class="example nohighlight" title="Data Stream Position as Fragment" id="DataStreamPosition_frag">
-				https://example.org/MyData.json#position(
-				  type=DataStreamPosition,
-				  value=401
-				)
-				</pre>	
-				
-				<p class="ex_title">Example for a <a href="#PositionRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Text Stream Position Refinement of CssSelector as Fragment" id="PositionRefinement_frag">
-				https://example.org/MyData.json#selector(
-				  type=CssSelector,
-				  value=p:nth-child(2),
-				  refinedBy=position(
-				    type=TextStreamPosition,
-				    value=8	
-				  )
-				)
-				</pre>	
 			</section>
 
 			<!-- <section>
@@ -2192,7 +2081,7 @@
 						All references to RDF and JSON-LD have been removed.
 					</li>
 					<li>
-						The reference to EPUBCFI in the definition for <a href="#FragmentSelector_def">Fragment Selectors</a> have been removed.
+						The reference to EPUBCFI in the definition for <a href="#FragmentSelector_def">Fragment Selectors</a> have been removed (but new reference has been added to section describing how to serialize select locators as fragment identifiers).
 					</li>
 					<li>
 						References to <a href="https://www.w3.org/TR/selectors-states/#dfn-class" class="externalDFN">Classes</a> (which, semantically, refer to RDF Classes) have been removed.
@@ -2212,27 +2101,23 @@
 					</li>
 
 					<li>
-						Two new Selectors have been added, namely
+						Three new Selectors have been added, namely
 						<ul>
 							<li><a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a> can be used to select a full resource, with its a, from a collection of resources, also identified with a URL;</li>
-							<li><a href="#MultipleSelector_def">Multiple Selectors</a> identify a collection of discrete selections, whether within the same or spread over several Sources.</li>
-						</ul>
+							<li><a href="#SpanSelector_def">Span Selectors</a> identify a continuous selection that spans multiple embedded resources in some ordered reading of a collection or group of resources identified with a URL.</li>
+							<li><a href="#MultipleResourceSelector_def">Multiple Resource Selectors</a> identify a ordered list of discrete selections, whether within a single resource or spread over multiple embedded resources included in a collection or group of resources identified with a URL
 					</li>
 
-					<li>
-						The <a href="#RangeSelector_def">Range Selector</a> has been extended by:
-
-						<ul>
-							<li>making explicit that the start and end selectors may refer to different resources;</li>
-							<li>adding a property to define a list of “intermediate” resources for ranges that spread over several of those.</li>
-						</ul>
-					</li>
-					
 					<li>A new kind of specifier, the <a>Position</a> specifier, has been added. Two Position specifier types have been added: 
 						<ul>
 							<li><a href="#TextStreamPosition_def">Text Stream Position</a> can be used to define a position within a text stream representation of a resource.</li>
 							<li><a href="#ByteStreamPosition_def">Byte Stream Position</a> can be used to define a position within a byte stream representation of a resource.</li>
 						</ul>					
+					</li>
+							
+					<li>
+					  The section on expressing Locators as fragment identifiers has been rescoped and limited to the 3 new types of Selectors introduced in this specification
+					  (albeit refinement is still allowed), and then only when this fragment identifier scheme has been registered for media types that are specific to collective resources.					  
 					</li>
 				</ul>
 			</section>


### PR DESCRIPTION
Assumes that PWPub resources will have their own media type and that fragment ids will be useful for selecting and locating content in PWPubs.
Also made a couple of minor editorial corrections in Appendix A that will need to be addressed if this PR is rejected.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://s3.amazonaws.com/pr-preview/tcole3/publ-loc/pull/35.html" title="Last updated on Nov 26, 2017, 7:04 PM GMT">Preview</a> | <a href="https://s3.amazonaws.com/pr-preview/w3c/publ-loc/723fcfd...tcole3:c165a26.html" title="Last updated on Nov 26, 2017, 7:04 PM GMT">Diff</a>