### PR TITLE
Frag Ids Only for ERS

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,26 @@
                     	"companyURL": "http://www.w3.org",
                   	}
               	],
+        localBiblio: [{
+        "cfi":
+	        {
+	          "authors": [
+	            "Peter Sorotokin",
+	            "Garth Conboy",
+	            "Brady Duga",
+	            "John Rivlin",
+	            "Don Beaver",
+	            "Kevin Ballard",
+	            "Alastair Fettes",
+	            "Daniel Weck"
+	          ],
+	          "title": "EPUB Canonical Fragment Identifiers",
+	          "href": "http://www.idpf.org/epub/linking/cfi/epub-cfi-20140628.html",
+	          "publisher": "IDPF",
+	          "rawDate": "2014-06-26",
+	          "status": "Recommended Specification"
+	        }        
+        }],      	
 				otherLinks: [{
 					key: "Editors/Authors of the original version",
 					data: [{
@@ -900,11 +920,11 @@
 				<p><em>This section is normative</em></p>
 
 				<p>
-					For some use cases it is required to identify a resource that is part of a group of resources, 
-					where that group has its own identity on the Web (and can be identified via its own URL). 
-					An example is selecting a resource that is a chapter of a Web Publication&nbsp;[[!wpub]]).
-					Given the URL of the Web Publication as the value of <code>source</code>, an Embedded Resource 
-					Selector can be used to select and identify the chapter through 
+					For some use cases it is required to identify a resource that is part of a collection or group of resources, 
+					where that collection has its own identity on the Web (and can be identified via its own URL). 
+					An example is selecting a resource that is a chapter of a Web Publication [[!wpub]] or Packaged Web Publication&nbsp;[[!pwpub]].
+					Given the URL of such a collective resource as the value of <code>source</code>, an Embedded Resource 
+					Selector can be used to select and identify an item within the collection, e.g., the chapter, through 
 					its <code>value</code> relationship.
 					This Selector is usually used in conjunction with additional Selectors, e.g., through 
 					<a href="#SelectorRefinement_def">refinement</a>.
@@ -938,7 +958,7 @@
   "source": "https://dauwhe.github.io/html-first/MobyDick.wpub",
   "selector": {
     "type": "EmbeddedResourceSelector",
-    "value": "https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg"
+    "value": "https://dauwhe.github.io/html-first/MobyDickNav/images/book-cover.jpg"
   }
 }				</pre>
 
@@ -959,8 +979,7 @@
       "value": "#elemid > .elemclass + p"
     }		
   }
-}
-						</pre>
+}	</pre>
 
 						<p>
 							For such a simple case, the usage of <code>scope</code> provides for a more succinct way of expressing the same information, see <a href="#scope_example">the example for a CSS Selector</a>. However, when combined with other selectors like, for example, a <a href="#SpanSelector_def">Span Selector</a>, the usage of this pattern becomes essential.
@@ -971,8 +990,123 @@
 				not have URLs (or to make clear that relative addressing is allowed?).</p>
 
 				<p class=issue data-number=12></p>
-					
+										
 			</section>
+
+        	<section id="ErsFragmentId_def" class="normative">
+        		<h3>Embedded Resource Selector serialized as a fragment identifier</h3>
+        		
+        		<p class="ednote">
+        			This assumes PWPs (at least) will have their own media type. If we decide to define a media type for PWPub (and/or WPub) resources, 
+        			we will keep this section and update examples and illustrations
+        			using file extension associated with new media type(s), i.e., the .pwpub file extension below is a placeholder. 							
+        			<em>But if no new media type for PWP or WP, then this section likely will be deleted.</em> 							
+        		</p>						
+        		<p class="issue" data-number="6"></p>
+        		
+        		<p><em>This section is normative</em></p>
+        		<p>
+        			For some simple use cases involving collective resources (of a registered collective resource media type), e.g., Packaged Web Publications, 
+        			it may be more convenient or more consistent with past practice to express a simple Embedded Resource selection as a fragment identifier&nbsp;[[url]] 
+        			that can be appended to the url of the collective resource, i.e., the <code>source</code> associated with the Embedded 
+        			Resource selection. (An informative precedent for this approach is the International Digital Publishing Forum 
+        			Recommended Specification, <em>EPUB Canonical Fragment Identifiers 1.1</em>&nbsp;[[cfi]], which defines a fragment identifer serialized model for 
+        			selecting and positioning	within resources of the	<code>application/epub+zip</code> media type.) 
+        		</p>
+        		
+        		<p>
+        			A mapping for serializing simple Embedded Resource selections
+        			as fragment identifiers is defined below.	This mapping allows the <a>Segment (of interest)</a> to be expressed in a single URL.
+        			Note that this representation is valid only if the URL for the <a>Source</a> (the collective resource) does not itself already include a fragment 
+        			identifier of its own.
+        	  </p>
+        		<p>
+        			An Embedded Resource Selector is seralized as a fragment identifier using a function-like syntax, i.e.: 
+        		</p>
+        		
+        		<ul>
+        			<li>The <code>source</code> for the selection is the base URL to which a <code>#</code> character is appended.</li>
+        			<li>Next comes the fixed string <code>ERS</code> (in lieu of a function name), followed by a single 'parameter' enclosed in parentheses.</li>
+        			<li>The single 'parameter' of the function-like notation is a URL, i.e., the <code>value</code> from the JSON serialization of the Embedded Resource Selector.</li>
+        		</ul>
+
+        		<p class="ex_title"><a href="#EmbeddedResourceSelector_ex">Example</a> from <a href="#EmbeddedResourceSelector_def"></a> serialized as a fragment identifier</p>
+        		<pre class="example highlight" title="Unrefiened Embedded Resource selection as fragment identifier" id="#EmbeddedResourceSelector_fragId_ex"
+>https://dauwhe.github.io/html-first/MobyDick.pwpub#ERS(
+    https://dauwhe.github.io/html-first/MobyDickNav/images/book-cover.jpg)	</pre>		
+
+        		<p>
+        			(A new line character has been introduced into the Example above to facilitate readability; in real usage such new line characters are not allowed in a URL.)
+        			The value of the URL 'parameter' appearing in a ERS fragment identifier SHOULD be percent encoded&nbsp;[[rfc3986]]; the encoding is a MUST for characters that may make the URL ambiguous, namely:
+        		</p>
+        		
+        		<!-- should be <table class="data"> but the stylesheet has issues.... -->
+        		<table >
+        			<thead>
+        				<tr>
+        					<td><strong>character</strong></td>
+        					<td><strong>code</strong></td>
+        				</tr>
+        			</thead>
+        			<tbody>
+        				<tr>
+        					<td>space</td>
+        					<td>%20</td>
+        				</tr>
+        				<tr>
+        					<td><code>=</code></td>
+        					<td>%3D</td>
+        				</tr>
+        				<tr>
+        					<td><code>,</code></td>
+        					<td>%2C</td>
+        				</tr>
+        				<tr>
+        					<td><code>#</code></td>
+        					<td>%23</td>
+        				</tr>
+        			</tbody>
+        		</table>
+        		
+        		<div class="note">
+        			<p>
+        				A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section 
+        				should be registered for each relevant media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
+        				Until such a registration is done, these fragment identifiers have the potential to conflict with other fragment identifier schemes specified by media type registrations.
+        				Consequently, this pattern should only be used when appending to the URL of a resource of a media-type for which this class of fragment identifer has been registered. 
+        			</p>
+        		</div>        		
+           <section id="ErsFragIdRefinement" class="normative">
+           	<h4>Refinement of ERS fragment identifiers</h4>
+        		<p>The fragment identifier serialization mapping of Embedded Resource Selectors
+        			generally does not support refinement, except that the URL 'parameter' may include its own fragment identifer, appropriate to 
+        			the media type of the resource identified by the URL.  The following example illustrates such a pattern. </p>
+        		
+           	<p class="ex_title">Example</p>
+        		<pre class="example highlight" title="Refined Embedded Resource Selector as Fragment Identifier" id="#RefinedEmbeddedResourceSelector_fragId_ex"
+>https://dauwhe.github.io/html-first/MobyDick.pwpub#ERS(
+  https://dauwhe.github.io/html-first/MobyDickNav/images/book-cover.jpg%23xywh%3D50%2C50%2C640%2C480)	</pre>	        		
+        		<p>
+        			The URL above is the result of mapping the JSON-serialized Embedded Resource Selector below; note that the link
+        			to the Media Fragments URI 1.0 Recommendation [[!media-frags]] cannot be mapped to the fragment identifier serialization, so the mapping is not entirely lossless.
+        		</p>
+        		
+           	<p class="ex_title">Example</p>
+        		<pre class="example highlight" title="Refined Embedded Resource Selector Fragment Identifier" id="FragRefinedEmbeddedResourceSelector_ex">{
+  "source": "https://dauwhe.github.io/html-first/MobyDick.pwpub",
+  "selector": {
+    "type": "EmbeddedResourceSelector",
+    "value": "https://dauwhe.github.io/html-first/MobyDickNav/images/book-cover.jpg",
+    "refinedBy": {
+      "type": "FragmentSelector",
+      "conformsTo": "http://www.w3.org/TR/media-frags/",
+      "value": "xywh=50,50,640,480"
+    }		
+  }
+}   </pre>
+           </section>
+</section>
+        	
 
 			<section id="SpanSelector_def" class="normative">
 				<h3>Span Selector</h3>
@@ -1115,7 +1249,7 @@
 
 				<h4>Example</h4>
 
-				<pre class="example highlight" title="Multi Selector" id="MultiSelector_ex">
+				<pre class="example highlight" title="Multi Resource Selector" id="MultiResourceSelector_ex">
 {
   "source": "https://textbook.example.org/",
   "selector": {
@@ -1578,378 +1712,6 @@
 			</section>
 		</section> <!-- /Position -->
 
-		<section id="frags">
-			<h3>Selectors, Positions, and States as Fragment Identifiers</h3>
-
-			<p>
-				Although <a data-lt="Selector">Selectors</a>, <a data-lt="Position">Positions</a>, and <a data-lt="State">States</a> provide a flexible way of identifying, e.g., a suitable <a>Segment</a> of a Resource, the fact that this is defined through an indirection using a <a>Locator</a> may be an obstacle for some applications. 
-			</p>
-
-			<p class="ednote">
-				We must add a good example. The original one referred to RDF, which is not relevant in this context.
-			</p>
-			
-			<p class="issue" data-number="6"></p>
-
-			<p>
-				To mitigate this issue, a mapping of <a data-lt="Selector">Selectors</a>, <a data-lt="Position">Positions</a>,
-				and <a data-lt="State">States</a> on URL fragments&nbsp;[[url]] is defined below. 
-				As a result of this mapping the selected <a>Segment</a>, targeted <a>Locus</a>, or relevant <a>State</a> is expressed in a 
-				single (albeit complex) URL.
-				In that URL the <a>Selector</a>, <a>Position</a>, or <a>State</a> is expressed as a 
-				single string and serves 
-				as a fragment which can be combined with the URL of the <a>Source</a>. 
-				Note that this representation is valid only if the URL for the <a>Source</a> does not contain a fragment 
-				identifier of its own (a URL may contain at most one fragment identification).
-			</p>
-
-			<p>
-				The syntax for mapping a <a>Selector</a>, <a>Position</a>, or <a>State</a> follows the same, “functional” syntax as used, 
-				for example, by the XPointer Framework&nbsp;[[xptr-framework]]:
-			</p>
-
-			<ul>
-				<li>The fragment uses the <code>selector(…)</code>, <code>position(...)</code>, or <code>state(…)</code> functional syntax.</li>
-				<li>The (comma separated) “parameters” of the functional notation are:
-					<ul>
-						<li>For the keys <code>startSelector</code> and <code>endSelector</code> the syntax is <code>key=selector(…)</code>,
-							  with the value following, recursively, the same syntax as a full <code>selector(...)</code> fragment;</li>
-						<li>For the key <code>refinedBy</code> the syntax is <code>refinedBy=selector(…)</code>, 
-							<code>refinedBy=position(...)</code>, or <code>refinedBy=state(...)</code>,
-							  with the value following, recursively, the same syntax as a full fragment;</li>
-						<li>For the key <code>selectors</code> the syntax is <code>selectors(…)</code> containing a comma separated list of selectors;</li>
-						<li>For the key <code>scope</code>, <code>scope=url</code> is added to the top level <code>selector(…)</code>, <code>position(…)</code>, or <code>state(…)</code>, although, strictly speaking, the scope value is set on the overall Locator rather than one of the <a>Specifiers</a>.</li>
-						<li>otherwise the key, and the corresponding value, follows the simple <code>key=value</code> syntax, e.g., <code>type=CssSelector</code>.</li>
-					</ul>
-				</li>
-			</ul>
-
-			<p>(see the examples below.)</p>
-
-			<p>The values SHOULD be percent encoded&nbsp;[[rfc3986]]; the encoding is a MUST for characters that may make the fragment ambiguous, namely:</p>
-
-			<!-- should be <table class="data"> but the stylesheet has issues.... -->
-			<table >
-				<thead>
-					<tr>
-						<td><strong>character</strong></td>
-						<td><strong>code</strong></td>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>space</td>
-						<td>%20</td>
-					</tr>
-					<tr>
-						<td><code>=</code></td>
-						<td>%3D</td>
-					</tr>
-					<tr>
-						<td><code>,</code></td>
-						<td>%2C</td>
-					</tr>
-					<tr>
-						<td><code>#</code></td>
-						<td>%23</td>
-					</tr>
-				</tbody>
-			</table>
-
-			<div class="note">
-				<p>
-					A fragment identifier is defined for a specific media type. This means that, formally, the fragment identifier syntax and semantics defined in this section should be registered for each media type separately by <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">IANA</a>.
-					Until such a registration is done, these fragment identifiers have the potential to conflict with other fragments possibly specified by the media type registrations.
-					Consequently, this pattern should only be used when the implementation cannot produce or manage the full representation described above. 
-				</p>
-			</div>
-
-			<section>
-				<h4>JSON examples converted to fragment identifiers</h4>
-
-				<p>
-					This section contains a mapping of all examples used in the definition of <a data-lt="Selector">Selectors</a> and <a data-lt="State">States</a> onto full URL-s with fragment identifiers.
-					Note that the examples below have been broken into several lines for a greater readability; in real usage such new lines are not allowed in a URL.
-				</p>
-
-				<!-- <p class="note">
-					A <a href="http://w3c.github.io/web-annotation/selector-note/converter/">simple converter tool</a> is also available to test the conversion of the JSON format to fragment and back.
-				</p> -->
-
-				<p class="ex_title"><a href="#FragmentSelector_ex">Example</a> for a <a href="#FragmentSelector_def"></a></p>
-				<pre class="example nohighlight" title="Fragment Selector as Fragment" id="FragmentSelector_frag">
-				http://example.org/video1#selector(
-				  type=FragmentSelector,
-				  conformsTo=http://www.w3.org/TR/media-frags,
-				  value=t%3D30%2C60
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#CssSelector_ex">Example</a> for a <a href="#CssSelector_def"></a></p>
-				<pre class="example nohighlight" title="CSS Selector as Fragment" id="CssSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-				  type=CssSelector,
-				  scope=https://dauwhe.github.io/html-first/MobyDick.wpub,
-				  value=%23elemid%20>%20.elemclass%20+%20p
-				)				 
-				</pre>
-
-				<p class="ex_title"><a href="#XPathSelector_ex">Example</a> for a <a href="#XPathSelector_def"></a></p>
-				<pre class="example nohighlight" title="XPath Selector as Fragment" id="XPathSelector_frag">
-				http://example.org/page1.html#selector(
-				  type=XPathSelector,
-				  value=/html/body/p[2]/table/tr[2]/td[3]/span
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#TextQuoteSelector_ex">Example</a> for a <a href="#TextQuoteSelector_def"></a></p>
-				<pre class="example nohighlight" title="Text Quote Selector as Fragment" id="TextQuoteSelector_frag">
-				http://example.org/page1#selector(
-				  type=TextQuoteSelector,
-				  exact=annotation,
-				  prefix=this%20is%20an%20,
-				  suffix=%20that%20has%20some
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#TextPositionSelector_ex">Example</a> for a <a href="#TextPositionSelector_def"></a></p>
-				<pre class="example nohighlight" title="Text Position Selector as Fragment" id="TextPositionSelector_frag">
-				http://example.org/ebook1#selector(
-				  type=TextPositionSelector,
-				  start=412,
-				  end=795
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#DataPositionSelector_ex">Example</a> for a <a href="#DataPositionSelector_def"></a></p>
-				<pre class="example nohighlight" title="Data Position Selector as Fragment" id="DataPositionSelector_frag">
-				http://example.org/diskimg1#selector(
-				  type=DataPositionSelector,
-				  start=4096,
-				  end=4104
-				)
-				</pre>
-
-				<p class="ex_title">First <a href="#SvgSelector_ex_1">example</a> for a <a href="#SvgSelector_def"></a></p>
-				<pre class="example nohighlight" title="SVG Selector as Fragment, referring to an external SVG" id="SvgSelector_frag_1">
-				http://example.org/map1#selector(
-				  type=SvgSelector,
-				  id=http://example.org/svg1
-				)
-				</pre>
-
-				<p class="ex_title">Second <a href="#SvgSelector_ex_2">example</a> for a <a href="#SvgSelector_def"></a></p>
-				<pre class="example nohighlight" title="SVG Selector as Fragment, using embedded SVG" id="SvgSelector_frag_2">
-				http://example.org/map1#selector(
-				  type=SvgSelector,
-				  value=&lt;svg:svg&gt;%20…%20&lt;/svg:svg&gt;
-				)
-				</pre>
-
-				<p class=note>
-					Please note that long SVG representations will produce very long URLs when produced according to this pattern.
-					Care should be taken in environments where there is a character limit to URLs, and implementers should consider publishing the SVG as a separate resource and using its URL as shown in <a href="#SvgSelector_frag_1">Example 22</a>.
-				</p>
-
-				<p class="ex_title"><a href="#EmbeddedResourceSelector_ex">Example</a> for an <a href="#EmbeddedesourceSelector_def"></a></p>
-				<pre class="example nohighlight" title="Embedded Resource Selector as Fragment" id="EmbeddedResourceSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-				  type=EmbeddedResourceSelector,
-				  value=https://dauwhe.github.io/html-first/MobyDickNav/images/moby-dick-book-cover.jpg
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#SelectorRefinement_ex">Example</a> for a <a href="#SelectorRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Selector Refinement as Fragment" id="SelectorRefinement_frag">
-				http://example.org/page1#selector(
-				  type=FragmentSelector,
-				  value=para5,
-				  refinedBy=selector(
-				    type=TextQuoteSelector,exact=Selected%20Text,
-				    prefix=text%20before%20the%20,
-				    suffix=%20and%20text%20after%20it
-				  )
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#RangeSelector_ex">Example</a> for a <a href="#RangeSelector_def"></a></p>
-				<pre class="example nohighlight" title="Range Selector as Fragment" id="RangeSelector_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#selector(
-				  type=RangeSelector,
-				  startSelector=selector(
-				    type=TextQuoteSelector,
-				    exact=Call%20me%20Ishmael.,
-				    suffix=Some%20years%20ago
-				  ),
-				  startSelector=selector(
-				    type=TextQuoteSelector,
-				      exact=He%20desires%20to%20paint%20you%20the%20dreamiest,%20, 
-				      prefix=But%20here%20is%20an%20artist.%20, 
-				      suffix=shadiest%2C%20quietest
-				  )
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#RangeSelector_ex_1">Example</a> for a <a href="#RangeSelector_def"></a> Over Several Resources</p>
-				<pre class="example nohighlight" title="Range Selector Over Several Resourcest" id="RangeSelector_frag_1">
-				https://dauwhe.github.io/html-first/MobyDick.wpub#selector(
-				  type=RangeSelector,
-				  startSelector=selector(
-				    type=EmbeddedResourceSelector,
-				    value=https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html,
-				    refinedBy=selector(
-				      type=TextQuoteSelector,
-				      exact=Call%20me%20Ishmael.,
-				      suffix=Some%20years%20ago
-				    )
-				  ),
-				  selectors(
-				    selector(
-				      type=EmbeddedResourceSelector,
-				      value=https://dauwhe.github.io/html-first/MobyDickNav/html/c002.html						
-				    ),
-				    selector(
-				      type=EmbeddedResourceSelector,
-				      value=https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html						
-				    )	
-				  ),
-				  endSelector=selector(
-				    type=EmbeddedResourceSelector,
-				    value=https://dauwhe.github.io/html-first/MobyDickNav/html/c003.html,
-				    refinedBy=selector(
-				      type=TextQuoteSelector,
-				      exact=He%20commenced%20dressing,
-				      suffix=%20at%top
-				    )
-				  )
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#MultiSelector_ex">Example</a> for a <a href="#MultiSelector_def"></a></p>
-				<pre class="example nohighlight" title="Multi Selector as Fragment" id="MultiSelector_frag">
-				https://textbook.example.org#selector(
-				  type=MultiSelector,
-				  selectors(
-				    selector(
-				      type=EmbeddedResourceSelector,
-				      value=https://textbook.example.org/section2.html,
-				      refinedBy=selector(
-				        type=CssSelector,
-				        value=body>section:nth-of-type(3)
-				      )
-				    ),
-				    selector(
-				      type=EmbeddedResourceSelector,
-				      value=https://textbook.example.org/section4.html
-				      refinedBy=selector(
-				        type=CssSelector,
-				        value=body>section:nth-of-type(6)
-				      )
-				    ),
-				    selector(
-				      type=EmbeddedResourceSelector,
-				      value=https://textbook.example.org/section7.html
-				      refinedBy=selector(
-				        type=CssSelector,
-				        value=body>section:nth-of-type(8)
-				      )
-				    )
-				  )
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#TimeState_ex">Example</a> for a <a href="#TimeState_def"></a></p>
-				<pre class="example nohighlight" title="Time State as Fragment" id="TimeState_frag">
-				http://example.org/page1#state(
-				  type=TimeState,
-				  cached=http://archive.example.org/copy1,
-				  sourceDate=2015-07-20T13:30:00Z
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#HttpRequestState_ex">Example</a> for a <a href="#HttpRequestState_def"></a></p>
-				<pre class="example nohighlight" title="HTTP Request State as Fragment" id="HttpRequestState_frag">
-				http://example.org/resource1#state(
-				  type=HttpRequestState,
-				  value=Accept:%20application/pdf
-				)
-				</pre>
-
-				<p class="ex_title"><a href="#StateRefinement_def">Example</a> for a <a href="#StateRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Refinement of States as Fragment" id="StateRefinement_frag">
-				http://example.org/ebook1#state(
-				  type=TimeState,sourceDate=2016-02-01T12:05:23Z,
-				  refinedBy=state(
-				    type=HttpRequestState,
-				    value=Accept:%20application/epub+zip
-				  )
-				)
-				</pre>
-				
-				<p class="ex_title">Example for a <a href="#TextStreamPosition_def"></a></p>
-				<pre class="example nohighlight" title="Text Stream Position as Fragment" id="TextStreamPosition_frag">
-				https://dauwhe.github.io/html-first/MobyDickNav/html/c001.html#position(
-				  type=TextStreamPosition,
-				  value=322,
-				  bias=after
-				)
-				</pre>				
-
-				<p class="ex_title">Example for a <a href="#DataStreamPosition_def"></a></p>
-				<pre class="example nohighlight" title="Data Stream Position as Fragment" id="DataStreamPosition_frag">
-				https://example.org/MyData.json#position(
-				  type=DataStreamPosition,
-				  value=401
-				)
-				</pre>	
-				
-				<p class="ex_title">Example for a <a href="#PositionRefinement_def"></a></p>
-				<pre class="example nohighlight" title="Text Stream Position Refinement of CssSelector as Fragment" id="PositionRefinement_frag">
-				https://example.org/MyData.json#selector(
-				  type=CssSelector,
-				  value=p:nth-child(2),
-				  refinedBy=position(
-				    type=TextStreamPosition,
-				    value=8	
-				  )
-				)
-				</pre>	
-			</section>
-
-			<!-- <section>
-				<h4>Serializing IRI to URL</h4>
-
-				<p>Care should be taken that to make use of a Selectors and States IRIs as URLs (i.e., not only as identifiers but as locators), each segment of the URL must be mapped to a corresponding URL segment following [[rfc3987]]. Applying percent encoding method for entire URL string might also cause unnecessary troubles. Some examples:</p>
-
-				<pre class="example nohighlight" title="Text Quote Selector in Japanese as a URL and a URL, respectively">
-					http://jp.example.org/page1
-						#selector(type=TextQuoteSelector,
-							exact=ペンを,
-							prefix=私は、,
-							suffix=持っています)
-
-					http://jp.example.org/page1
-						#selector(type=TextQuoteSelector,
-							exact=%E3%83%9A%E3%83%B3%E3%82%92,
-							prefix=%E7%A7%81%E3%81%AF%E3%80%81,
-							suffix=%E6%8C%81%E3%81%A3%E3%81%A6%E3%81%84%E3%81%BE%E3%81%99)
-				</pre>
-
-				<pre class="example nohighlight" title="Percent Encoded Text Quote Selector as a URL and a URL, respectively">
-					http://example.org/page1
-						#selector(type=TextQuoteSelector,exact=annotation,
-							prefix=this%20is%20an%20,suffix=%20that%20has%20some)
-
-					http://example.org/page1
-						#selector(type=TextQuoteSelector,exact=annotation,
-							prefix=this%2520is%2520an%2520,suffix=%2520that%2520has%2520some)
-				</pre>
-
-				<p>Note that the URL may also contain an internationalized domain name, which must be encoded as well (see [[rfc3490]]).</p>
-
-			</section> -->
-		</section>
-
 		<section id="media_selector">
 			<h2>Correspondence Among Media Types and Selectors</h2>
 	
@@ -2192,7 +1954,7 @@
 						All references to RDF and JSON-LD have been removed.
 					</li>
 					<li>
-						The reference to EPUBCFI in the definition for <a href="#FragmentSelector_def">Fragment Selectors</a> have been removed.
+						The reference to EPUBCFI in the definition for <a href="#FragmentSelector_def">Fragment Selectors</a> have been removed (but new informative reference has been added to section describing how to <a href="#ErsFragmentId_def">serialize Embedded Resource Selectors as fragment identifiers</a>).
 					</li>
 					<li>
 						References to <a href="https://www.w3.org/TR/selectors-states/#dfn-class" class="externalDFN">Classes</a> (which, semantically, refer to RDF Classes) have been removed.
@@ -2212,27 +1974,22 @@
 					</li>
 
 					<li>
-						Two new Selectors have been added, namely
+						Three new Selectors have been added, namely
 						<ul>
 							<li><a href="#EmbeddedResourceSelector_def">Embedded Resource Selectors</a> can be used to select a full resource, with its a, from a collection of resources, also identified with a URL;</li>
-							<li><a href="#MultipleSelector_def">Multiple Selectors</a> identify a collection of discrete selections, whether within the same or spread over several Sources.</li>
-						</ul>
+							<li><a href="#SpanSelector_def">Span Selectors</a> identify a continuous selection that spans multiple embedded resources in some ordered reading of a collection or group of resources identified with a URL.</li>
+							<li><a href="#MultipleResourceSelector_def">Multiple Resource Selectors</a> identify a ordered list of discrete selections, whether within a single resource or spread over multiple embedded resources included in a collection or group of resources identified with a URL
 					</li>
 
-					<li>
-						The <a href="#RangeSelector_def">Range Selector</a> has been extended by:
-
-						<ul>
-							<li>making explicit that the start and end selectors may refer to different resources;</li>
-							<li>adding a property to define a list of “intermediate” resources for ranges that spread over several of those.</li>
-						</ul>
-					</li>
-					
 					<li>A new kind of specifier, the <a>Position</a> specifier, has been added. Two Position specifier types have been added: 
 						<ul>
 							<li><a href="#TextStreamPosition_def">Text Stream Position</a> can be used to define a position within a text stream representation of a resource.</li>
 							<li><a href="#ByteStreamPosition_def">Byte Stream Position</a> can be used to define a position within a byte stream representation of a resource.</li>
 						</ul>					
+					</li>
+							
+					<li>
+						The section on expressing any <a>Locator</a> as fragment identifier has been deleted in favor of a short section entitled, <a href="#ErsFragmentId_def"></a>.					  
 					</li>
 				</ul>
 			</section>


### PR DESCRIPTION
Delete section entitled, Selectors, Positions, and States as Fragment Identifiers
insert sub-section, Embedded Resource Selector serialized as a fragment identifier
clean up appendices


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tcole3/publ-loc/pull/36.html" title="Last updated on Nov 29, 2017, 6:24 PM GMT">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-loc/723fcfd...tcole3:ba31498.html" title="Last updated on Nov 29, 2017, 6:24 PM GMT">Diff</a>